### PR TITLE
fix: update the pattern to improve BEM class name validation

### DIFF
--- a/packages/eslint-plugin-slds/src/rules/enforce-bem-class.ts
+++ b/packages/eslint-plugin-slds/src/rules/enforce-bem-class.ts
@@ -28,7 +28,7 @@ export = {
 
   create(context) {
     const pattern =
-      /^(?:[a-z0-9]+(?:-[a-z0-9]+)*)(__[a-z0-9]+(?:-[a-z0-9]+)*)?(--[a-z0-9]+(?:-[a-z0-9]+)*)?$/;
+   /^([a-z]+|[a-z]+-[a-z]+|slds-[a-z0-9]+(-[a-z0-9]+)*(--[a-z0-9]+(-[a-z0-9]+)*)?(__[a-z0-9]+)?)$/;
 
     const checkNaming = (name) => pattern.test(name);
 


### PR DESCRIPTION
Before - After
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/f5c5c4dd-27e1-48e5-b0e4-a30e201c2576" />

<img width="623" alt="image" src="https://github.com/user-attachments/assets/d338a041-f624-47ab-83f2-e3db445acffb" />

<img width="1152" alt="image" src="https://github.com/user-attachments/assets/19fdcbb6-0b8d-4bc6-a527-4336a39713ca" />

Only these content are affected, rest are same.