### PR TITLE
fix(node-version): added support for node v 18.20.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,72 +1,46 @@
 {
     "version": "0.2.0",
     "configurations": [
-          {
-            "name": "Run Stylelint on CSS",
-            "type": "node",
-            "request": "launch",
-            "runtimeExecutable": "/Users/lnemalipuri/.volta/bin/npx",
-            "runtimeArgs": [
-              "stylelint",
-              "force-app/main/default/lwc/myComponent/test.css",
-              "--config=packages/test-repository/.stylelintrc.yml"
-            ],
-            "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen"
-          },
-          {
-            "name": "Run Eslint on HTML",
-            "type": "node",
-            "request": "launch",
-            "runtimeExecutable": "/Users/lnemalipuri/.volta/bin/npx",
-            "runtimeArgs": [
-              "eslint",
-              "force-app/main/default/lwc/myComponent/myComponent.html"
-            ],
-            "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen"
-          },
-          {
-            "name": "Auto fix using Stylelint",
-            "type": "node",
-            "request": "launch",
-            "runtimeExecutable": "/Users/lnemalipuri/.volta/bin/npx",
-            "runtimeArgs": [
-              "stylelint",
-              "force-app/main/default/lwc/myComponent/test.css",
-              "--fix"
-            ],
-            "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen"
-          },
-          {
-            "type": "node",
-            "request": "launch",
-            "name": "Debug Jest Tests",
-            "runtimeExecutable": "${workspaceFolder}/node_modules/jest/bin/jest.js",
-            "runtimeArgs": ["--runInBand"],
-            "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "env": {
-              "NODE_ENV": "test"
-            }
-          },
-          {
-            "type": "node",
-            "request": "launch",
-            "name": "Run report",
-            "runtimeExecutable": "node",
-            "args": [
-              "${workspaceFolder}/node_modules/@salesforce-ux/stylelint-plugin-slds/build/report.js",
-              "-d", "packages/test-repository"
-            ],
-            "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen"
-          }
+      {
+        "name": "Run CLI Lint:Styles",
+        "request": "launch",
+        "runtimeExecutable": "${env:HOME}/.nvm/versions/node/v18.20.6/bin/node",
+        "runtimeArgs": [
+          "${workspaceFolder}/packages/cli/build/index.js",
+          "lint:styles"
+        ],
+        "console": "integratedTerminal",
+        "skipFiles": [
+          "<node_internals>/**"
+        ],
+        "type": "node"
+      },
+      {
+        "name": "Run CLI Lint:Components",
+        "request": "launch",
+        "runtimeExecutable": "${env:HOME}/.nvm/versions/node/v18.20.6/bin/node",
+        "runtimeArgs": [
+          "${workspaceFolder}/packages/cli/build/index.js",
+          "lint:components"
+        ],
+        "console": "integratedTerminal",
+        "skipFiles": [
+          "<node_internals>/**"
+        ],
+        "type": "node"
+      },{
+        "name": "Run CLI Report",
+        "request": "launch",
+        "runtimeExecutable": "${env:HOME}/.nvm/versions/node/v18.20.6/bin/node",
+        "runtimeArgs": [
+          "${workspaceFolder}/packages/cli/build/index.js",
+          "report"
+        ],
+        "console": "integratedTerminal",
+        "skipFiles": [
+          "<node_internals>/**"
+        ],
+        "type": "node"
+      }      
     ]
   }

--- a/packages/cli/gulpfile.js
+++ b/packages/cli/gulpfile.js
@@ -23,6 +23,7 @@ const compileTs = async ()=>{
     platform: "node",
     format:"esm",
     packages:'external',
+    sourcemap:true,
     plugins:[esbuildPluginFilePathExtensions({
       esmExtension:"js"
     })]

--- a/packages/cli/src/services/lint-runner.ts
+++ b/packages/cli/src/services/lint-runner.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { BatchProcessor, BatchResult } from './batch-processor';
 import { WorkerConfig, WorkerResult, LintResult } from '../types';
 import { Logger } from '../utils/logger';
+import { resolveDirName } from '../utils/nodeVersionUtil';
 
 export interface LintOptions {
   fix?: boolean;
@@ -21,7 +22,7 @@ export class LintRunner {
   ): Promise<LintResult[]> {
     try {
       const workerScript = path.resolve(
-        import.meta.dirname ,
+        resolveDirName(import.meta) ,
         '../workers',
         workerType === 'style' ? 'stylelint.worker.js' : 'eslint.worker.js'
       );

--- a/packages/cli/src/utils/nodeVersionUtil.ts
+++ b/packages/cli/src/utils/nodeVersionUtil.ts
@@ -1,7 +1,9 @@
 import semver from 'semver';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 import { Logger } from './logger'; // Ensure this path is correct
 
-export const REQUIRED_NODE_VERSION = '20.18.3';
+export const REQUIRED_NODE_VERSION = '18.20.0';
 
 /**
  * Checks if the current Node.js version meets the required version.
@@ -23,3 +25,20 @@ export function validateNodeVersion() {
     process.exit(1);
   }
 }
+
+/**
+ * Util to resolve dirName from import meta compatible with node v18
+ * Letst version of node have import.meta.dirname
+ * @param importMeta 
+ * @returns 
+ */
+export function resolveDirName(importMeta:ImportMeta){
+  if("dirname" in importMeta){
+    return importMeta.dirname;
+  }
+  return dirname(fileURLToPath((importMeta as ImportMeta).url));
+}
+
+export function resolvePath(specifier:string, parentURL = import.meta.url) {
+  return new URL(specifier, parentURL).href;
+};

--- a/packages/metadata/gulpfile.js
+++ b/packages/metadata/gulpfile.js
@@ -55,6 +55,7 @@ async function generateBundle() {
     platform: "node",
     format:"esm",
     packages:'external',
+    sourcemap:true,
     plugins:[esbuildPluginFilePathExtensions({
       esmExtension:"js"
     })]

--- a/packages/stylelint-plugin-slds/gulpfile.js
+++ b/packages/stylelint-plugin-slds/gulpfile.js
@@ -23,6 +23,7 @@ const compileTs = async ()=>{
     platform: "node",
     format:"esm",
     packages:'external',
+    sourcemap:true,
     plugins:[esbuildPluginFilePathExtensions({
       esmExtension:"js"
     })]


### PR DESCRIPTION
- added util to resolve dirname in old version of node
- updated required node version to 18.20.0
- generating source maps, to support breakpoints in ts file
- added launch configs