### PR TITLE
fix(eslint): setting useEslintrc to flase

### DIFF
--- a/packages/cli/src/workers/eslint.worker.ts
+++ b/packages/cli/src/workers/eslint.worker.ts
@@ -8,7 +8,7 @@ class ESLintWorker extends BaseWorker<WorkerConfig, WorkerResult> {
   constructor() {
     super();
     this.eslint = new ESLint({
-      useEslintrc: true,
+      useEslintrc: false,
       fix: this.task.config.fix,
       overrideConfigFile: this.task.config.configPath
     });


### PR DESCRIPTION
 If false is present, ESLint doesn’t load configuration files (.eslintrc.* files). Only the configuration of the constructor options is valid.