### PR TITLE
Support Sharif and CSV report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ logs/
 .sfdx
 .codegenie
 
+slds-linter-report.csv

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "chalk": "^4.1.2",
     "commander": "^13.1.0",
     "eslint": "^8.0.0",
+    "export-to-csv": "^1.4.0",
     "globby": "^14.1.0",
     "import-meta-resolve": "^4.1.0",
     "json-stream-stringify": "^3.1.6",

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -76,9 +76,7 @@ export function registerReportCommand(program: Command): void {
           Logger.success(`SARIF report generated: ${combinedReportPath}\n`);
         } else if (reportFormat === 'csv') {
           spinner.text = 'Generating CSV report...';
-          const cwd = process.cwd();
-
-          const csvReportPath = await CsvReportGenerator.generate([...styleResults, ...componentResults], cwd);
+          const csvReportPath = await CsvReportGenerator.generate([...styleResults, ...componentResults]);
           Logger.success(`CSV report generated: ${csvReportPath}\n`);
         } else {
           throw new Error(`Invalid format: ${reportFormat}. Supported formats: sarif, csv`);

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -10,16 +10,19 @@ import { StyleFilePatterns, ComponentFilePatterns } from '../services/file-patte
 import { LintRunner } from '../services/lint-runner';
 import { ReportGenerator } from '../services/report-generator';
 import { DEFAULT_ESLINT_CONFIG_PATH, DEFAULT_STYLELINT_CONFIG_PATH, LINTER_CLI_VERSION } from '../services/config.resolver';
+import { mkConfig, generateCsv, asString } from 'export-to-csv';
+import { writeFile } from 'fs/promises';
 
 export function registerReportCommand(program: Command): void {
   program
     .command('report')
-    .description('Generate SARIF report from linting results')
+    .description('Generate report from linting results')
     .argument('[directory]', 'Target directory to scan (defaults to current directory). Support glob patterns')
     .addOption(new Option('-d, --directory <path>', 'Target directory to scan (defaults to current directory). Support glob patterns').hideHelp())    
     .option('-o, --output <path>', 'Output directory for reports (defaults to current directory)')
     .option('--config-stylelint <path>', 'Path to stylelint config file')
     .option('--config-eslint <path>', 'Path to eslint config file')
+    .option('--format <type>', 'Output format (sarif or csv)', 'sarif')
     .action(async (directory: string, options: CliOptions) => {
       const spinner = ora('Starting report generation...');
       try {        
@@ -34,10 +37,11 @@ export function registerReportCommand(program: Command): void {
           // If  -d, --directory option is passed, prompt deprecation warning
           Logger.newLine().warning(chalk.yellow(
             `WARNING: --directory, -d option is deprecated. Supply as argument instead.
-Example: npx @salesforce-ux/slds-linter report ${options.directory}
-`));
+            Example: npx @salesforce-ux/slds-linter report ${options.directory}`
+          ));
         }
         spinner.start();
+        
         // Run styles linting
         spinner.text = 'Running styles linting...';
         const styleFileBatches = await FileScanner.scanFiles(normalizedOptions.directory, {
@@ -60,21 +64,71 @@ Example: npx @salesforce-ux/slds-linter report ${options.directory}
           configPath: normalizedOptions.configEslint
         });
 
-        // Generate report
-        spinner.text = 'Generating SARIF report...';
-        const combinedReportPath = path.join(normalizedOptions.output, 'slds-linter-report.sarif');
-        await ReportGenerator.generateSarifReport([...styleResults, ...componentResults], {
-          outputPath: combinedReportPath,
-          toolName: 'slds-linter',
-          toolVersion: LINTER_CLI_VERSION
-        });
+        // Generate report based on format
+        const reportFormat = options.format.toLowerCase();
+        
+        if (reportFormat === 'sarif') {
+          spinner.text = 'Generating SARIF report...';
+          const combinedReportPath = path.join(normalizedOptions.output, 'slds-linter-report.sarif');
+          await ReportGenerator.generateSarifReport([...styleResults, ...componentResults], {
+            outputPath: combinedReportPath,
+            toolName: 'slds-linter',
+            toolVersion: LINTER_CLI_VERSION
+          });
+          Logger.success(`SARIF report generated: ${combinedReportPath}\n`);
+        } else if (reportFormat === 'csv') {
+          spinner.text = 'Generating CSV report...';
+          const csvConfig = mkConfig({
+            filename: 'slds-linter-report',
+            fieldSeparator: ',',
+            quoteStrings: true,
+            decimalSeparator: '.',
+            showLabels: true,
+            useTextFile: false,
+            useBom: true,
+            useKeysAsHeaders: true,
+          });
+          
+          const transformedResults = [...styleResults, ...componentResults].flatMap(result =>
+            [
+              ...result.errors.map(error => ({
+                "File Path": result.filePath,
+                "Message": error.message,
+                "Severity": error.severity === 1 ? 'warning' : 'error',
+                "Rule ID": error.ruleId || 'N/A',
+                "Start Line": error.line,
+                "Start Column": error.column,
+                "End Column": error.endColumn || error.column, // Default to start column if missing
+                "Type": 'Error'
+              })),
+              ...result.warnings.map(warning => ({
+                "File Path": result.filePath,
+                "Message": warning.message,
+                "Severity": warning.severity === 1 ? 'warning' : 'error',
+                "Rule ID": warning.ruleId || 'N/A',
+                "Start Line": warning.line,
+                "Start Column": warning.column,
+                "End Column": warning.endColumn || warning.column, // Default to start column if missing
+                "Type": 'Warning'
+              }))
+            ]
+          );
+          
+          const csvData = generateCsv(csvConfig)(transformedResults);
+          const csvString = asString(csvData);
+          const csvReportPath = path.join(normalizedOptions.output, `${csvConfig.filename}.csv`);
+          await writeFile(csvReportPath, csvString);
+          Logger.success(`CSV report generated: ${csvReportPath}\n`);
+        } else {
+          throw new Error(`Invalid format: ${reportFormat}. Supported formats: sarif, csv`);
+        }
+        
         spinner.succeed('Report generation completed');
-        Logger.success(`SARIF report generated: ${combinedReportPath}\n`);
         process.exit(0);
       } catch (error: any) {
         spinner?.fail('Report generation failed');
-        Logger.error(`Failed to generate SARIF report: ${error.message}`);
+        Logger.error(`Failed to generate report: ${error.message}`);
         process.exit(1);
       }
     });
-} 
+}

--- a/packages/cli/src/services/report-generator.ts
+++ b/packages/cli/src/services/report-generator.ts
@@ -152,7 +152,7 @@ export class ReportGenerator {
 }
 
 export class CsvReportGenerator {
-  static async generate(results: any[], cwd: string) {
+  static async generate(results: any[]) {
     const csvConfig = mkConfig({
       filename: 'slds-linter-report',
       fieldSeparator: ',',
@@ -162,6 +162,8 @@ export class CsvReportGenerator {
       useBom: true,
       useKeysAsHeaders: true,
     });
+
+    const cwd = process.cwd();
 
     const transformedResults = results.flatMap((result: { errors: any[]; filePath: string; warnings: any[]; }) =>
       [

--- a/packages/cli/src/services/report-generator.ts
+++ b/packages/cli/src/services/report-generator.ts
@@ -158,7 +158,6 @@ export class CsvReportGenerator {
       fieldSeparator: ',',
       quoteStrings: true,
       decimalSeparator: '.',
-      showLabels: true,
       useTextFile: false,
       useBom: true,
       useKeysAsHeaders: true,

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -5,6 +5,7 @@ export interface CliOptions {
   configStylelint?: string; // Used for stylelint config when command is lint
   configEslint?: string; // Used for eslint config when command is lint
   editor?: string;
+  format?: string;
 }
 
 export interface LintResult {

--- a/packages/cli/src/utils/cli-args.ts
+++ b/packages/cli/src/utils/cli-args.ts
@@ -39,6 +39,7 @@ export function normalizeCliOptions(
     editor: "vscode",
     configStylelint: "",
     configEslint: "",
+    format: "sarif",
     ...defultOptions,
     ...options,
     directory: nomalizeDirPath(options.directory),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,6 +2129,11 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
+export-to-csv@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/export-to-csv/-/export-to-csv-1.4.0.tgz#03fb42a4a4262cd03bde57a7b9bcad115149cf4b"
+  integrity sha512-6CX17Cu+rC2Fi2CyZ4CkgVG3hLl6BFsdAxfXiZkmDFIDY4mRx2y2spdeH6dqPHI9rP+AsHEfGeKz84Uuw7+Pmg==
+
 extend@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"


### PR DESCRIPTION
[slds-linter-report.csv](https://github.com/user-attachments/files/19221954/slds-linter-report.csv)

npx slds-linter report --help                                                                       ─╯
Usage: npx @salesforce-ux/slds-linter@latest report [options] [directory]

Generate report from linting results

Arguments:
  directory                  Target directory to scan (defaults to current directory). Support glob
                             patterns

Options:
  -o, --output <path>        Output directory for reports (defaults to current directory)
  --config-stylelint <path>  Path to stylelint config file
  --config-eslint <path>     Path to eslint config file
  --format <type>            Output format (sarif or csv) (default: "sarif")
  -h, --help                 display help for command
  
  
