### PR TITLE
Standardize message in node API lint usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage/
 .sldslinter/
 *.sarif
 *.tgz
+*.csv
 
 # IDE and editor files
 .idea/

--- a/packages/cli/examples/node-api-example.mjs
+++ b/packages/cli/examples/node-api-example.mjs
@@ -7,6 +7,7 @@
  */
 
 import { lint, report } from '@salesforce-ux/slds-linter/executor';
+import { printLintResults } from '@salesforce-ux/slds-linter/utils';
 import fs from 'fs';
 import path from 'path';
 
@@ -23,10 +24,8 @@ async function lintDirectory() {
     console.log(`Found ${results.length} files with issues`);
     
     // Display summary of issues
-    results.forEach(result => {
-      console.log(`File: ${path.basename(result.filePath)}`);
-      console.log(`- Errors: ${result.errors.length}, Warnings: ${result.warnings.length}`);
-    });
+    printLintResults(results);
+
   } catch (error) {
     console.error('Linting failed:', error);
   }
@@ -48,14 +47,15 @@ async function generateSarifReport() {
         filePath: '../../demo/small-set/hardcoded-values.css',
         errors: [],
         warnings: [{
-          line: 1,
-          column: 1,
-          endColumn: 10,
-          message: 'Sample warning message for testing',
-          ruleId: 'test-rule',
+          line: 2,
+          column: 13,
+          endColumn: 17,
+          message: "There’s no replacement styling hook for the 100% static value. Remove the static value. (slds/no-hardcoded-values-slds2).",
+          ruleId: 'slds/no-hardcoded-values-slds2',
           severity: 1
         }]
       }];
+      printLintResults(lintResults);
     }
     
     const reportStream = await report({
@@ -93,11 +93,20 @@ async function generateCsvReport() {
           line: 1,
           column: 1,
           endColumn: 10,
-          message: 'Sample warning message for testing',
-          ruleId: 'test-rule',
+          message: "Overriding .slds-button__icon isn’t supported. To differentiate SLDS and custom classes, create a CSS class in your namespace. Examples: myapp-input, myapp-button.",
+          ruleId: 'slds/no-slds-class-overrides',
+          severity: 1
+        },
+        {
+          line: 2,
+          column: 13,
+          endColumn: 17,
+          message: "There’s no replacement styling hook for the 23% static value. Remove the static value. (slds/no-hardcoded-values-slds2).",
+          ruleId: 'slds/no-hardcoded-values-slds2',
           severity: 1
         }]
       }];
+      printLintResults(lintResults);
     }
     
     // Generate report using the lint results

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,10 @@
     "./executor": {
       "types": "./build/executor/index.d.ts",
       "default": "./build/executor/index.js"
+    },
+    "./utils": {
+      "types": "./build/utils/index.d.ts",
+      "default": "./build/utils/index.js"
     }
   },
   "files": [

--- a/packages/cli/src/executor/index.ts
+++ b/packages/cli/src/executor/index.ts
@@ -54,8 +54,7 @@ export async function lint(config: LintConfig): Promise<LintResult[]> {
     
     // Combine results from both linters
     const combinedResults = [...styleResults, ...componentResults];
-    
-    return combinedResults;
+    return standardizeLintMessages(combinedResults);
   } catch (error: any) {
     // Enhance error with context for better debugging
     const errorMessage = `Linting failed: ${error.message}`;
@@ -118,6 +117,35 @@ export async function report(config: ReportConfig, results?: LintResult[]): Prom
     Logger.error(errorMessage);
     throw new Error(errorMessage);
   }
+}
+
+// Helper to standardize message field for all warnings and errors
+function standardizeLintMessages(results: LintResult[]): LintResult[] {
+  return results.map(result => ({
+    ...result,
+    errors: result.errors.map(entry => {
+      let msgObj;
+      try {
+        msgObj = JSON.parse(entry.message);
+        // If already has message, keep as is
+        if (typeof msgObj === 'object' && 'message' in msgObj) {
+          return { ...entry, message: JSON.stringify(msgObj) };
+        }
+      } catch {}
+      // Otherwise, wrap as { message }
+      return { ...entry, message: JSON.stringify({ message: entry.message }) };
+    }),
+    warnings: result.warnings.map(entry => {
+      let msgObj;
+      try {
+        msgObj = JSON.parse(entry.message);
+        if (typeof msgObj === 'object' && 'message' in msgObj && 'suggestions' in msgObj) {
+          return { ...entry, message: JSON.stringify(msgObj) };
+        }
+      } catch {}
+      return { ...entry, message: JSON.stringify({ message: entry.message, suggestions: [] }) };
+    })
+  }));
 }
 
 export type { LintResult, LintResultEntry, LintConfig, ReportConfig, ExitCode, WorkerResult, SarifResultEntry } from '../types'; 

--- a/packages/cli/src/executor/index.ts
+++ b/packages/cli/src/executor/index.ts
@@ -129,21 +129,21 @@ function standardizeLintMessages(results: LintResult[]): LintResult[] {
         msgObj = JSON.parse(entry.message);
         // If already has message, keep as is
         if (typeof msgObj === 'object' && 'message' in msgObj) {
-          return { ...entry, message: JSON.stringify(msgObj) };
+          return { ...entry, message: msgObj.message };
         }
       } catch {}
       // Otherwise, wrap as { message }
-      return { ...entry, message: JSON.stringify({ message: entry.message }) };
+      return { ...entry, message: entry.message };
     }),
     warnings: result.warnings.map(entry => {
       let msgObj;
       try {
         msgObj = JSON.parse(entry.message);
         if (typeof msgObj === 'object' && 'message' in msgObj) {
-          return { ...entry, message: JSON.stringify(msgObj) };
+          return { ...entry, message: msgObj.message };
         }
       } catch {}
-      return { ...entry, message: JSON.stringify({ message: entry.message }) };
+      return { ...entry, message: entry.message };
     })
   }));
 }

--- a/packages/cli/src/executor/index.ts
+++ b/packages/cli/src/executor/index.ts
@@ -127,9 +127,9 @@ function standardizeLintMessages(results: LintResult[]): LintResult[] {
       let msgObj;
       try {
         msgObj = JSON.parse(entry.message);
-        // If already has message, keep as is
+        // If already an object, spread all properties into the entry
         if (typeof msgObj === 'object' && 'message' in msgObj) {
-          return { ...entry, message: msgObj.message };
+          return { ...entry, ...msgObj };
         }
       } catch {}
       // Otherwise, wrap as { message }
@@ -140,7 +140,7 @@ function standardizeLintMessages(results: LintResult[]): LintResult[] {
       try {
         msgObj = JSON.parse(entry.message);
         if (typeof msgObj === 'object' && 'message' in msgObj) {
-          return { ...entry, message: msgObj.message };
+          return { ...entry, ...msgObj };
         }
       } catch {}
       return { ...entry, message: entry.message };

--- a/packages/cli/src/executor/index.ts
+++ b/packages/cli/src/executor/index.ts
@@ -139,11 +139,11 @@ function standardizeLintMessages(results: LintResult[]): LintResult[] {
       let msgObj;
       try {
         msgObj = JSON.parse(entry.message);
-        if (typeof msgObj === 'object' && 'message' in msgObj && 'suggestions' in msgObj) {
+        if (typeof msgObj === 'object' && 'message' in msgObj) {
           return { ...entry, message: JSON.stringify(msgObj) };
         }
       } catch {}
-      return { ...entry, message: JSON.stringify({ message: entry.message, suggestions: [] }) };
+      return { ...entry, message: JSON.stringify({ message: entry.message }) };
     })
   }));
 }

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -1,0 +1,2 @@
+export { printLintResults } from './lintResultsUtil';
+export { Logger } from './logger';


### PR DESCRIPTION
Helper added to standardize message field for all warnings and errors

The requirement was to print a message once data streaming is complete when the SLDS-Linter Node API is invoked via Bazel.
