### PR TITLE
fix(package): enforce TypeScript and Yarn version requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   ],
   "packageManager": "yarn@4.2.2",
   "engines": {
-    "node": ">=20.18.3"
+    "node": ">=20.18.3",
+    "yarn": ">=4.2.2"
   },
   "scripts": {
     "prepare": "husky install",
@@ -45,7 +46,7 @@
     "rimraf": "^6.0.1",
     "semver": "^7.7.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3"
+    "typescript": "5.3.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bazel runs on different platforms, and developers often work in varied environments. This can lead to inconsistencies—especially when dependencies are specified using ^, which allows minor or patch upgrades. For example, different developers may end up using slightly different versions of TypeScript, leading to unexpected build or lint issues.
 
 Fix : 

-  Pin TypeScript to exact version 5.3.3 for consistent Bazel builds
-  Add Yarn engine requirement (>=4.2.2) for workspace commands