### PR TITLE
feat(stylelint): add no-slds-namespace rule to enforce token naming conventions

### DIFF
--- a/packages/stylelint-plugin-slds/.stylelintrc.yml
+++ b/packages/stylelint-plugin-slds/.stylelintrc.yml
@@ -52,6 +52,9 @@ overrides:
       slds/no-slds-var-without-fallback:
         - true
         - severity: warning
+      slds/no-slds-namespace:
+        - true
+        - severity: warning
 
     sourceMap:
       - false

--- a/packages/stylelint-plugin-slds/src/rules/index.ts
+++ b/packages/stylelint-plugin-slds/src/rules/index.ts
@@ -11,6 +11,7 @@ import enforceSdsToSldsHooks from './enforce-sds-to-slds-hooks';
 import reduceAnnotations from './reduce-annotations';
 import { noHardcodedValuesSlds, noHardcodedValuesSldsPlus } from './no-hardcoded-value';
 import noSldsVarWithoutFallback from './no-slds-var-without-fallback';
+import noSldsNamespace from './no-slds-namespace';
 
 export default [
   enforceSdsToSldsHooks,
@@ -26,5 +27,6 @@ export default [
   noSldsPrivateVar,
   noImportantTag,
   reduceAnnotations,
-  noSldsVarWithoutFallback
+  noSldsVarWithoutFallback,
+  noSldsNamespace
 ];

--- a/packages/stylelint-plugin-slds/src/rules/no-slds-namespace/index.ts
+++ b/packages/stylelint-plugin-slds/src/rules/no-slds-namespace/index.ts
@@ -1,0 +1,132 @@
+import { Declaration, Root } from 'postcss';
+import stylelint, { PostcssResult, Rule, RuleSeverity } from 'stylelint';
+import ruleMetadata from '../../utils/rulesMetadata';
+import replacePlaceholders from '../../utils/util';
+import metadata from '@salesforce-ux/sds-metadata';
+import { isTargetProperty } from '../../utils/prop-utills';
+import { forEachVarFunction } from '../../utils/decl-utils';
+import valueParser from 'postcss-value-parser';
+
+const sldsPlusStylingHooks = metadata.sldsPlusStylingHooks;
+
+// Generate values to hooks mapping using only global hooks
+// shared hooks are private/ undocumented APIs, so they should not be recommended to customers
+// Ref this thread: https://salesforce-internal.slack.com/archives/C071J0Q3FNV/p1743010620921339?thread_ts=1743009353.385429&cid=C071J0Q3FNV
+const allSldsHooks = [...sldsPlusStylingHooks.global, ...sldsPlusStylingHooks.component];
+
+
+const { utils, createPlugin }: typeof stylelint = stylelint;
+
+const ruleName: string = 'slds/no-slds-namespace';
+
+const { severityLevel = 'error', warningMsg = '', errorMsg = '', ruleDesc = 'No description provided' } = ruleMetadata(ruleName) || {};
+
+const toSldsToken = (sdsToken: string) => sdsToken.replace('--sds-', '--slds-')
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+    expected: (token: string) => {
+        const tokenWithoutNamespace = token.replace('--slds-', '').replace('--sds-', '');
+        return replacePlaceholders(warningMsg, { token, tokenWithoutNamespace })
+    },
+});
+
+function shouldIgnoreDetection(sdsToken: string) {
+    // Ignore if entry found in the list or not starts with reserved namespace
+    if(sdsToken.startsWith('--sds-') || sdsToken.startsWith('--slds-')){
+        return allSldsHooks.includes(toSldsToken(sdsToken))
+    }
+    return true;
+}
+
+/**
+ * 
+ * Example:
+ *  .THIS  .demo {
+ *    border: 1px solid var(--slds-my-own-token));
+ *  }
+ * 
+ */
+function detectRightSide(decl: Declaration, basicReportProps: Partial<stylelint.Problem>) {
+
+    forEachVarFunction(decl, (node: valueParser.FunctionNode, startOffset: number) => {
+        const tokenNode = node.nodes[0];
+        const oldValue = tokenNode.value;
+        if (shouldIgnoreDetection(oldValue)) {
+            // Ignore if entry not found in the list or the token is marked to use further
+            return;
+        }
+
+        const index = startOffset + tokenNode.sourceIndex;
+        const endIndex = startOffset + tokenNode.sourceEndIndex;
+        const message = messages.expected(oldValue);
+
+        utils.report(<stylelint.Problem>{
+            message,
+            index,
+            endIndex,
+            ...basicReportProps
+        });
+    });
+}
+
+/**
+ * 
+ * Example:
+ *  .THIS  .demo {
+ *    --slds-my-own-token: 50%;
+ *  }
+ * 
+ */
+function detectLeftSide(decl: Declaration, basicReportProps: Partial<stylelint.Problem>) {
+    // Usage on left side
+    const { prop } = decl;
+    if (shouldIgnoreDetection(prop)) {
+        // Ignore if entry not found in the list or the token is marked to use further
+        return;
+    }
+    const startIndex = decl.toString().indexOf(prop);
+    const endIndex = startIndex + prop.length;
+
+    const message = messages.expected(prop);
+
+    utils.report(<stylelint.Problem>{
+        message,
+        index: startIndex,
+        endIndex,
+        ...basicReportProps
+    });
+}
+
+
+const ruleFunction: Partial<stylelint.Rule> = (primaryOptions: boolean, { severity = severityLevel as RuleSeverity, propertyTargets = [] } = {}) => {
+
+    return (root: Root, result: PostcssResult) => {
+
+        root.walkDecls((decl) => {
+            if (!isTargetProperty(decl.prop, propertyTargets)) {
+                return;
+            }
+
+            const basicReportProps = {
+                node: decl,
+                result,
+                ruleName,
+                severity,
+            };
+
+            detectRightSide(decl, basicReportProps);
+            detectLeftSide(decl, basicReportProps);
+        });
+    };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = {
+    url: '',
+    fixable: true
+};
+
+// Export the plugin
+export default createPlugin(ruleName, <stylelint.Rule>ruleFunction);
+

--- a/packages/stylelint-plugin-slds/src/utils/rules.ts
+++ b/packages/stylelint-plugin-slds/src/utils/rules.ts
@@ -200,6 +200,16 @@ const rulesMetadata = {
     errorMsg: "Your code uses the ${cssVar} styling hook without a fallback value. Styling hooks are unavailable in some Salesforce environments. To render your component correctly in all environments, add this fallback value: var(${cssVar}, ${recommendation}) . To make this fallback value brand-aware, use a branded design token instead of a static value. See Design Tokens on v1.lightningdesignsystem.com.",
     ruleDesc: "Add fallback values to SLDS styling hooks. The fallback values are used in Salesforce environments where styling hooks are unavailable.",
   },
+
+
+  "slds/no-slds-namespace": {
+    name: "slds/no-slds-namespace",
+    severityLevel: "warning",
+    warningMsg: "Using slds namespace for ${token} isn't supported. To differentiate SLDS and custom tokens, create a token in your namespace. Example: --myapp-${tokenWithoutNamespace}",
+    ruleDesc: "Create a token in your namespace to differentiate SLDS and custom tokens. For more information, see the Lightning Web Components Developer Guide.",
+  },
+
+
 } as const; // Ensures it's a readonly object
 
 export default rulesMetadata;

--- a/packages/stylelint-plugin-slds/tests/rules/no-slds-namespace/no-slds-namespace.spec.ts
+++ b/packages/stylelint-plugin-slds/tests/rules/no-slds-namespace/no-slds-namespace.spec.ts
@@ -1,0 +1,89 @@
+import stylelint, { LinterResult, LinterOptions } from 'stylelint';
+import sldsPlugin from '../../../src/index';
+
+const { lint }: typeof stylelint = stylelint;
+
+describe('no-slds-namespace', () => {
+  const testCases = [
+    {
+      message:
+        'Using slds namespace for --slds-my-own-token isn\'t supported. To differentiate SLDS and custom tokens, create a token in your namespace. Example: --myapp-my-own-token',
+      code: `
+        .example {
+          --slds-my-own-token: #fff;
+        }
+      `,
+      ruleName: 'slds/no-slds-namespace'
+    },
+    {
+      message:
+        'Using slds namespace for --slds-custom-color isn\'t supported. To differentiate SLDS and custom tokens, create a token in your namespace. Example: --myapp-custom-color',
+      code: `
+        .example {
+          color: var(--slds-custom-color);
+        }
+      `,
+      ruleName: 'slds/no-slds-namespace'
+    },
+    {
+      message: null,
+      code: `
+        .example {
+          --myapp-valid-token: #fff;
+        }
+      `,
+      ruleName: 'slds/no-slds-namespace'
+    },
+    {
+      message: null,
+      code: `
+        .example {
+          color: var(--myapp-valid-token);
+        }
+      `,
+      ruleName: 'slds/no-slds-namespace'
+    },
+    {
+      message: null,
+      code: `
+        .example {
+          --slds-c-button-color-background: #fff;
+        }
+      `,
+      ruleName: 'slds/no-slds-namespace'
+    },
+    {
+      message: null,
+      code: `
+        .example {
+          color: var(--slds-c-button-color-background);
+        }
+      `,
+      ruleName: 'slds/no-slds-namespace'
+    },
+  ];
+
+  testCases.forEach((testCase, index) => {
+    it(`test rule #${index}`, async () => {
+      const linterResult: LinterResult = await lint({
+        code: testCase.code,
+        config: {
+          plugins: [sldsPlugin],
+          rules: {
+            [testCase.ruleName]: true,
+          },
+        },
+      } as LinterOptions);
+
+      const messages = linterResult.results[0]._postcssResult?.messages || [];
+
+      // Test for the presence or absence of the message
+      if (testCase.message) {
+        expect(messages.length).toEqual(1);
+        expect(messages[0].text).toContain(testCase.message);
+      } else {
+        expect(messages.length).toEqual(0);
+      }
+    });
+  });
+}); 

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+      "module": "ESNext", // or ES2022
+      "target": "ESNext",
+      "moduleResolution": "node",
+      "esModuleInterop": true,
+      "skipLibCheck": true
+    },
+    "exclude": ["node_modules"]
+  }


### PR DESCRIPTION
- Introduced a new stylelint rule `slds/no-slds-namespace` to prevent the use of the `slds` namespace for custom tokens.
- Updated rules metadata to include descriptions and severity levels for the new rule.
- Added tests to validate the behavior of the new rule against various cases.

This enhancement aims to ensure that custom tokens are clearly differentiated from SLDS tokens, promoting better naming practices in stylesheets.