### PR TITLE
feat(stylelint): add no-unsupported-var-fallback rule to enforce valid fallback usage

### DIFF
--- a/demo/small-set/no-unsupported-var-fallback
+++ b/demo/small-set/no-unsupported-var-fallback
@@ -1,0 +1,17 @@
+.test-class-1{
+    color: var(--lwc-color-background-1, var(--slds-g-color-border-1));
+}
+
+.test-class-2{
+    color: var(--lwc-color-background-1, var(--slds-g-color-border-1));
+}
+
+.test-class-3{
+    color: var(--lwc-color-background-1, var(--slds-g-color-border-1, var(--lwc-color-background-2)));
+}
+
+
+.test-class-4{
+    color: var(--slds-g-color-border-1, var(--lwc-color-background-1, var(--slds-g-color-border-2)));
+}
+

--- a/packages/stylelint-plugin-slds/.stylelintrc.yml
+++ b/packages/stylelint-plugin-slds/.stylelintrc.yml
@@ -55,6 +55,9 @@ overrides:
       slds/no-slds-namespace:
         - true
         - severity: warning
+      slds/no-unsupported-var-fallback:
+        - true
+        - severity: warning
 
     sourceMap:
       - false

--- a/packages/stylelint-plugin-slds/src/rules/index.ts
+++ b/packages/stylelint-plugin-slds/src/rules/index.ts
@@ -12,6 +12,7 @@ import reduceAnnotations from './reduce-annotations';
 import { noHardcodedValuesSlds, noHardcodedValuesSldsPlus } from './no-hardcoded-value';
 import noSldsVarWithoutFallback from './no-slds-var-without-fallback';
 import noSldsNamespace from './no-slds-namespace';
+import noUnsupportedVarFallback from './no-unsupported-var-fallback';
 
 export default [
   enforceSdsToSldsHooks,
@@ -28,5 +29,6 @@ export default [
   noImportantTag,
   reduceAnnotations,
   noSldsVarWithoutFallback,
-  noSldsNamespace
+  noSldsNamespace,
+  noUnsupportedVarFallback
 ];

--- a/packages/stylelint-plugin-slds/src/rules/no-slds-class-overrides/index.ts
+++ b/packages/stylelint-plugin-slds/src/rules/no-slds-class-overrides/index.ts
@@ -5,7 +5,6 @@ import metadata from '@salesforce-ux/sds-metadata';
 import ruleMetadata from '../../utils/rulesMetadata';
 import { getClassNodesAtEnd } from '../../utils/selector-utils';
 import replacePlaceholders from '../../utils/util';
-import { hasMatchedProperty } from '../../utils/prop-utills';
 const { utils, createPlugin }: typeof stylelint = stylelint;
 const sldsClasses = metadata.sldsClasses;
 

--- a/packages/stylelint-plugin-slds/src/rules/no-unsupported-var-fallback/index.ts
+++ b/packages/stylelint-plugin-slds/src/rules/no-unsupported-var-fallback/index.ts
@@ -1,0 +1,102 @@
+import { Declaration, Root } from 'postcss';
+import stylelint, { PostcssResult, Rule, RuleSeverity } from 'stylelint';
+import ruleMetadata from '../../utils/rulesMetadata';
+import replacePlaceholders from '../../utils/util';
+import metadata from '@salesforce-ux/sds-metadata';
+import { isTargetProperty } from '../../utils/prop-utills';
+import { forEachVarFunction, getFallbackToken, getVarToken } from '../../utils/decl-utils';
+import valueParser from 'postcss-value-parser';
+
+const sldsPlusStylingHooks = metadata.sldsPlusStylingHooks;
+
+// Generate values to hooks mapping using only global hooks
+// shared hooks are private/ undocumented APIs, so they should not be recommended to customers
+// Ref this thread: https://salesforce-internal.slack.com/archives/C071J0Q3FNV/p1743010620921339?thread_ts=1743009353.385429&cid=C071J0Q3FNV
+const allSldsHooks = [...sldsPlusStylingHooks.global, ...sldsPlusStylingHooks.component];
+
+
+const { utils, createPlugin }: typeof stylelint = stylelint;
+
+const ruleName: string = 'slds/no-unsupported-var-fallback';
+
+const { severityLevel = 'error', warningMsg = '', errorMsg = '', ruleDesc = 'No description provided' } = ruleMetadata(ruleName) || {};
+
+const toSldsToken = (sdsToken: string='') => (sdsToken || '').replace('--sds-', '--slds-')
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+    expected: (lwcToken: string, sldsToken: string) => {
+        return replacePlaceholders(warningMsg, { lwcToken, sldsToken })
+    },
+});
+
+function hasUnsupportedFallback(lwcToken: string, sldsToken: string): boolean {
+    const safeSldsToken = toSldsToken(sldsToken);
+    return lwcToken && safeSldsToken 
+    && lwcToken.startsWith('--lwc-') 
+    && safeSldsToken.startsWith('--slds-') 
+    && allSldsHooks.includes(safeSldsToken);
+}
+
+/**
+ * 
+ * Example:
+ *  .THIS  .demo {
+ *    color: var(--lwc-color-background-1, var(--sds-g-color-background-1));
+ *  }
+ * 
+ */
+function detectRightSide(decl: Declaration, basicReportProps: Partial<stylelint.Problem>) {
+
+    forEachVarFunction(decl, (node: valueParser.FunctionNode, startOffset: number) => {
+        const lwcToken = getVarToken(node);
+        const sldsToken = getFallbackToken(node);
+
+        if(!hasUnsupportedFallback(lwcToken, sldsToken)){
+            return;
+        }
+
+        const index = startOffset + node.sourceIndex;
+        const endIndex = startOffset + node.sourceEndIndex;
+        const message = messages.expected(lwcToken, sldsToken);
+
+        utils.report(<stylelint.Problem>{
+            message,
+            index,
+            endIndex,
+            ...basicReportProps
+        });
+    }, false);
+}
+
+
+const ruleFunction: Partial<stylelint.Rule> = (primaryOptions: boolean, { severity = severityLevel as RuleSeverity, propertyTargets = [] } = {}) => {
+
+    return (root: Root, result: PostcssResult) => {
+
+        root.walkDecls((decl) => {
+            if (!isTargetProperty(decl.prop, propertyTargets)) {
+                return;
+            }
+
+            const basicReportProps = {
+                node: decl,
+                result,
+                ruleName,
+                severity,
+            };
+
+            detectRightSide(decl, basicReportProps);
+        });
+    };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = {
+    url: '',
+    fixable: true
+};
+
+// Export the plugin
+export default createPlugin(ruleName, <stylelint.Rule>ruleFunction);
+

--- a/packages/stylelint-plugin-slds/src/utils/decl-utils.ts
+++ b/packages/stylelint-plugin-slds/src/utils/decl-utils.ts
@@ -25,6 +25,15 @@ export function getVarToken(node: valueParser.Node): string {
   return isVarFunction(node)? (<valueParser.FunctionNode>node).nodes[0].value: '';
 }
 
+export function getFallbackFunction(node: valueParser.FunctionNode): valueParser.FunctionNode {
+  return node.nodes.find(isVarFunction) as valueParser.FunctionNode;
+}
+
+export function getFallbackToken(node: valueParser.FunctionNode): string {
+  const fallbackFunction = getFallbackFunction(node);
+  return fallbackFunction? getVarToken(fallbackFunction): '';
+}
+
 export function forEachVarFunction(decl:Declaration, callback: (node: valueParser.Node, startOffset: number) => void, shallow: boolean = true) {
     const startOffset = decl.toString().indexOf(decl.value);
     const parsedValue = valueParser(decl.value);

--- a/packages/stylelint-plugin-slds/src/utils/rules.ts
+++ b/packages/stylelint-plugin-slds/src/utils/rules.ts
@@ -209,6 +209,13 @@ const rulesMetadata = {
     ruleDesc: "Create a token in your namespace to differentiate SLDS and custom tokens. For more information, see the Lightning Web Components Developer Guide.",
   },
 
+  "slds/no-unsupported-var-fallback": {
+    name: "slds/no-unsupported-var-fallback",
+    severityLevel: "warning",
+    warningMsg: "Using ${sldsToken} as fallback value for ${lwcToken} isn't supported. For more information, see the Lightning Web Components Developer Guide.",
+    ruleDesc: "Using slds token as fallback value for lwc token is not supported.",
+  },
+
 
 } as const; // Ensures it's a readonly object
 

--- a/packages/stylelint-plugin-slds/tests/rules/no-unsupported-var-fallback/no-unsupported-var-fallback.spec.ts
+++ b/packages/stylelint-plugin-slds/tests/rules/no-unsupported-var-fallback/no-unsupported-var-fallback.spec.ts
@@ -1,0 +1,108 @@
+import stylelint, { LinterResult, LinterOptions } from 'stylelint';
+import sldsPlugin from '../../../src/index';
+
+const { lint }: typeof stylelint = stylelint;
+
+describe('no-unsupported-var-fallback', () => {
+  const testCases = [
+    {
+      message:
+        'Using --slds-g-color-border-1 as fallback value for --lwc-color-background-1 isn\'t supported. For more information, see the Lightning Web Components Developer Guide.',
+      code: `
+        .example {
+          color: var(--lwc-color-background-1, var(--slds-g-color-border-1));
+        }
+      `,
+      ruleName: 'slds/no-unsupported-var-fallback'
+    },
+    {
+      message:
+        'Using --slds-g-color-border-1 as fallback value for --lwc-color-background-1 isn\'t supported. For more information, see the Lightning Web Components Developer Guide.',
+      code: `
+        .example {
+          color: var(--lwc-color-background-1, var(--slds-g-color-border-1));
+        }
+      `,
+      ruleName: 'slds/no-unsupported-var-fallback'
+    },
+    {
+      message:
+        'Using --slds-g-color-border-1 as fallback value for --lwc-color-background-1 isn\'t supported. For more information, see the Lightning Web Components Developer Guide.',
+      code: `
+        .example {
+          color: var(--lwc-color-background-1, var(--slds-g-color-border-1, var(--lwc-color-background-2)));
+        }
+      `,
+      ruleName: 'slds/no-unsupported-var-fallback'
+    },
+    {
+      message: 'Using --slds-g-color-border-2 as fallback value for --lwc-color-background-1 isn\'t supported. For more information, see the Lightning Web Components Developer Guide.',
+      code: `
+        .example {
+          color: var(--slds-g-color-border-1, var(--lwc-color-background-1, var(--slds-g-color-border-2)));
+        }
+      `,
+      ruleName: 'slds/no-unsupported-var-fallback'
+    },
+    {
+      message: null,
+      code: `
+        .example {
+          color: var(--myapp-color-background-1, var(--slds-g-color-border-1));
+        }
+      `,
+      ruleName: 'slds/no-unsupported-var-fallback'
+    },
+    {
+      message: null,
+      code: `
+        .example {
+          color: var(--lwc-color-background-1, var(--myapp-color-border-1));
+        }
+      `,
+      ruleName: 'slds/no-unsupported-var-fallback'
+    },
+    {
+      message: null,
+      code: `
+        .example {
+          color: var(--slds-g-color-border-1);
+        }
+      `,
+      ruleName: 'slds/no-unsupported-var-fallback'
+    },
+    {
+      message: null,
+      code: `
+        .example {
+          color: var(--lwc-color-background-1);
+        }
+      `,
+      ruleName: 'slds/no-unsupported-var-fallback'
+    },
+  ];
+
+  testCases.forEach((testCase, index) => {
+    it(`test rule #${index}`, async () => {
+      const linterResult: LinterResult = await lint({
+        code: testCase.code,
+        config: {
+          plugins: [sldsPlugin],
+          rules: {
+            [testCase.ruleName]: true,
+          },
+        },
+      } as LinterOptions);
+
+      const messages = linterResult.results[0]._postcssResult?.messages || [];
+
+      // Test for the presence or absence of the message
+      if (testCase.message) {
+        expect(messages.length).toEqual(1);
+        expect(messages[0].text).toContain(testCase.message);
+      } else {
+        expect(messages.length).toEqual(0);
+      }
+    });
+  });
+}); 


### PR DESCRIPTION
- Introduced a new stylelint rule `slds/no-unsupported-var-fallback` to prevent the use of SLDS tokens as fallback values for LWC tokens.
- Implemented utility functions to detect unsupported fallback scenarios in CSS declarations.
- Updated rules metadata to include descriptions and severity levels for the new rule.
- Added tests to validate the behavior of the new rule against various cases, ensuring compliance with styling guidelines.

This enhancement aims to improve the robustness of styling practices by ensuring that unsupported fallback values are not used, promoting better adherence to SLDS standards.