### PR TITLE
Adding changes for warning/errors

### DIFF
--- a/demo/small-set/aura/demoComponent.css
+++ b/demo/small-set/aura/demoComponent.css
@@ -53,3 +53,8 @@
     color: var(--lwc-colorTextIconDefault);
     border-radius: var(--lwc-borderRadiusMedium);
 } 
+
+
+THIS .secondaryFields > li > *:last-child:before {
+    color: t(colorTextPlaceholder);
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce-ux/slds-linter",
-  "version": "0.2.2",
+  "version": "0.2.2-alpha-2-alpha.0",
   "description": "SLDS Linter CLI tool for linting styles and components",
   "keywords": [
     "lightning design system linter",
@@ -36,8 +36,8 @@
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
-    "@salesforce-ux/eslint-plugin-slds": "0.2.2",
-    "@salesforce-ux/stylelint-plugin-slds": "0.2.2",
+    "@salesforce-ux/eslint-plugin-slds": "0.2.2-alpha-2-alpha.0",
+    "@salesforce-ux/stylelint-plugin-slds": "0.2.2-alpha-2-alpha.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "chalk": "^4.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce-ux/slds-linter",
-  "version": "0.2.2-alpha-2-alpha.0",
+  "version": "0.2.2-internal-beta.0",
   "description": "SLDS Linter CLI tool for linting styles and components",
   "keywords": [
     "lightning design system linter",
@@ -36,8 +36,8 @@
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
-    "@salesforce-ux/eslint-plugin-slds": "0.2.2-alpha-2-alpha.0",
-    "@salesforce-ux/stylelint-plugin-slds": "0.2.2-alpha-2-alpha.0",
+    "@salesforce-ux/eslint-plugin-slds": "0.2.2-internal-beta.0",
+    "@salesforce-ux/stylelint-plugin-slds": "0.2.2-internal-beta.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "chalk": "^4.1.2",

--- a/packages/cli/src/workers/eslint.worker.ts
+++ b/packages/cli/src/workers/eslint.worker.ts
@@ -8,7 +8,6 @@ class ESLintWorker extends BaseWorker<WorkerConfig, WorkerResult> {
   constructor() {
     super();
     this.eslint = new ESLint({
-      useEslintrc: false,
       fix: this.task.config.fix,
       overrideConfigFile: this.task.config.configPath
     });

--- a/packages/cli/src/workers/stylelint.worker.ts
+++ b/packages/cli/src/workers/stylelint.worker.ts
@@ -40,10 +40,11 @@ class StylelintWorker extends BaseWorker<WorkerConfig, WorkerResult> {
           ruleId: warning.rule
         }));
 
+      const combinedResults = [...warnings, ...errors].sort((a, b) => a.line - b.line);
       return {
         file: filePath,
-        warnings,
-        errors
+        warnings: combinedResults,
+        errors: []
       };
     } catch (error: any) {
       return {

--- a/packages/cli/src/workers/stylelint.worker.ts
+++ b/packages/cli/src/workers/stylelint.worker.ts
@@ -19,16 +19,31 @@ class StylelintWorker extends BaseWorker<WorkerConfig, WorkerResult> {
       const fileResult = result.results[0];
 
       // Convert stylelint results to our format
-      return {
-        file: filePath,
-        warnings: fileResult.warnings.map(warning => ({
+      // Stylelint uses severity: "ignore", "warning", "error"
+      const warnings = fileResult.warnings
+        .filter(warning => warning.severity === 'warning')
+        .map(warning => ({
           line: warning.line,
           column: warning.column,
           endColumn: warning.endColumn,
           message: warning.text,
           ruleId: warning.rule
-        })),
-        errors: [] // Stylelint doesn't differentiate between warnings and errors
+        }));
+
+      const errors = fileResult.warnings
+        .filter(warning => warning.severity === 'error')
+        .map(warning => ({
+          line: warning.line,
+          column: warning.column,
+          endColumn: warning.endColumn,
+          message: warning.text,
+          ruleId: warning.rule
+        }));
+
+      return {
+        file: filePath,
+        warnings,
+        errors
       };
     } catch (error: any) {
       return {

--- a/packages/cli/src/workers/stylelint.worker.ts
+++ b/packages/cli/src/workers/stylelint.worker.ts
@@ -19,32 +19,16 @@ class StylelintWorker extends BaseWorker<WorkerConfig, WorkerResult> {
       const fileResult = result.results[0];
 
       // Convert stylelint results to our format
-      // Stylelint uses severity: "ignore", "warning", "error"
-      const warnings = fileResult.warnings
-        .filter(warning => warning.severity === 'warning')
-        .map(warning => ({
-          line: warning.line,
-          column: warning.column,
-          endColumn: warning.endColumn,
-          message: warning.text,
-          ruleId: warning.rule
-        }));
-
-      const errors = fileResult.warnings
-        .filter(warning => warning.severity === 'error')
-        .map(warning => ({
-          line: warning.line,
-          column: warning.column,
-          endColumn: warning.endColumn,
-          message: warning.text,
-          ruleId: warning.rule
-        }));
-
-      const combinedResults = [...warnings, ...errors].sort((a, b) => a.line - b.line);
       return {
         file: filePath,
-        warnings: combinedResults,
-        errors: []
+        warnings: fileResult.warnings.map(warning => ({
+          line: warning.line,
+          column: warning.column,
+          endColumn: warning.endColumn,
+          message: warning.text,
+          ruleId: warning.rule
+        })).sort((a, b) => a.line - b.line),
+        errors: [] // Stylelint doesn't differentiate between warnings and errors
       };
     } catch (error: any) {
       return {

--- a/packages/eslint-plugin-slds/package.json
+++ b/packages/eslint-plugin-slds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce-ux/eslint-plugin-slds",
-  "version": "0.2.2",
+  "version": "0.2.2-alpha-2-alpha.0",
   "main": "build/index.js",
   "files": [
     "build/**",

--- a/packages/eslint-plugin-slds/package.json
+++ b/packages/eslint-plugin-slds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce-ux/eslint-plugin-slds",
-  "version": "0.2.2-alpha-2-alpha.0",
+  "version": "0.2.2-internal-beta.0",
   "main": "build/index.js",
   "files": [
     "build/**",

--- a/packages/stylelint-plugin-slds/.stylelintrc.yml
+++ b/packages/stylelint-plugin-slds/.stylelintrc.yml
@@ -16,24 +16,24 @@ overrides:
       # slds/no-important-tag:
       #   - true
       #   - severity: warning
-      # slds/no-hardcoded-values-slds1:
-      #   - true
-      #   - severity: error
+      slds/no-hardcoded-values-slds1:
+        - true
+        - severity: error
       slds/no-hardcoded-values-slds2:
         - true
         - severity: warning
-      # slds/no-deprecated-tokens-slds1:
-      #   - true
-      #   - severity: error
-      # slds/lwc-token-to-slds-hook: ## Cannot be public as the data is not final. 
-      #   - true
-      #   - severity: warning
-      # slds/enforce-bem-usage:
-      #   - true
-      #   - severity: warning
-      # slds/no-deprecated-slds-classes:
-      #   - true
-      #   - severity: warning
+      slds/no-deprecated-tokens-slds1:
+        - true
+        - severity: error
+      slds/lwc-token-to-slds-hook: ## Cannot be public as the data is not final. 
+        - true
+        - severity: warning
+      slds/enforce-bem-usage:
+        - true
+        - severity: warning
+      slds/no-deprecated-slds-classes:
+        - true
+        - severity: warning
       slds/no-slds-private-var:
         - true
         - severity: warning

--- a/packages/stylelint-plugin-slds/package.json
+++ b/packages/stylelint-plugin-slds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce-ux/stylelint-plugin-slds",
-  "version": "0.2.2",
+  "version": "0.2.2-alpha-2-alpha.0",
   "type": "module",
   "main": "build/index.js",
   "files": [

--- a/packages/stylelint-plugin-slds/package.json
+++ b/packages/stylelint-plugin-slds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce-ux/stylelint-plugin-slds",
-  "version": "0.2.2-alpha-2-alpha.0",
+  "version": "0.2.2-internal-beta.0",
   "type": "module",
   "main": "build/index.js",
   "files": [


### PR DESCRIPTION
Fix: The report generated out of slds-linter is not exactly the same when I use `--fix` or without it.

For example: 
When .css is 

THIS .secondaryFields > li > *:last-child:before {
    color: t(colorTextPlaceholder);
}

This is getting fixed as the below when I run lint command with `--fix`

THIS .secondaryFields > li > *:last-child:before {
    color: var(--slds-g-color-on-surface-1, var(--lwc-colorTextPlaceholder, t(colorTextPlaceholder)));
}

But the same is not getting flagged as warning when I run lint command without `--fix`.


After debugging, its found that the lint errors not sorted based on the line number hence it feels like we are missing some errors/warnings.