### PR TITLE
feat(stylelint): add rule utility to check if rules are enabled and update no-hardcoded-value rule logic

### DIFF
--- a/packages/stylelint-plugin-slds/src/rules/no-deprecated-slds-classes/index.ts
+++ b/packages/stylelint-plugin-slds/src/rules/no-deprecated-slds-classes/index.ts
@@ -4,7 +4,6 @@ import stylelint, { PostcssResult, Rule, RuleSeverity } from 'stylelint';
 import ruleMetadata from '../../utils/rulesMetadata';
 import { getClassNodesFromSelector } from '../../utils/selector-utils';
 import replacePlaceholders from '../../utils/util';
-import { hasMatchedProperty } from '../../utils/prop-utills';
 
 const { utils, createPlugin } = stylelint;
 const deprecatedClasses = metadata.deprecatedClasses;

--- a/packages/stylelint-plugin-slds/src/rules/no-hardcoded-value/noHardcodedValue.rule.ts
+++ b/packages/stylelint-plugin-slds/src/rules/no-hardcoded-value/noHardcodedValue.rule.ts
@@ -12,8 +12,11 @@ import type { ValueToStylingHooksMapping } from '@salesforce-ux/sds-metadata';
 import { handleFontProps } from './handlers/fontHandler';
 import { forEachDensifyValue } from '../../utils/density-utils';
 import { isFontProperty } from '../../utils/fontValueParser';
+import { isRuleEnabled } from '../../utils/rule-utils';
 
 const { createPlugin } = stylelint;
+
+
 
 export const createNoHardcodedValueRule = (
   ruleName: string,
@@ -33,6 +36,11 @@ export const createNoHardcodedValueRule = (
     { severity = severityLevel as RuleSeverity, propertyTargets = [] } = {}
   ) => {
     return (root: Root, result: PostcssResult) => {
+      // do not recommend slds1 hooks as replacement for hardcoded values if slds2 is enabled
+      if (ruleName === 'slds/no-hardcoded-values-slds1' && isRuleEnabled(result, 'slds/no-hardcoded-values-slds2')) {
+        return;
+      }
+
       root.walkDecls((decl) => {
         if (!isTargetProperty(decl.prop, propertyTargets)) {
           return;

--- a/packages/stylelint-plugin-slds/src/utils/rule-utils.ts
+++ b/packages/stylelint-plugin-slds/src/utils/rule-utils.ts
@@ -1,0 +1,14 @@
+import { PostcssResult } from "stylelint";
+
+export function isRuleEnabled(result: PostcssResult, ruleName: string) {
+    const rules:any = result?.stylelint?.config?.rules || {};
+    if(ruleName in rules){
+        if(Array.isArray(rules[ruleName])){
+            return rules[ruleName][0] === true;
+        } else if(rules[ruleName] !== undefined && rules[ruleName] !== null){
+            return true;
+        } else if(rules[ruleName] === false){
+            return false;
+        }
+    }
+}


### PR DESCRIPTION


- Introduced a new utility function `isRuleEnabled` to determine if a specific stylelint rule is active.
- Updated the `noHardcodedValue` rule to prevent recommending slds1 hooks when slds2 is enabled.
- Removed unused import in the `no-deprecated-slds-classes` rule file.