### PR TITLE
Bundling shared utils keeping other packages as external, reducing maintainability for any new packages/dependencies introduced.

### DIFF
--- a/packages/eslint-plugin-slds/gulpfile.mjs
+++ b/packages/eslint-plugin-slds/gulpfile.mjs
@@ -3,7 +3,11 @@ import { series, src, dest } from 'gulp';
 import { rimraf} from 'rimraf'
 import {task} from "gulp-execa";
 import path from 'path';
+import { dirname, resolve } from 'path';
+import { createRequire } from 'module';
 import pkg from "./package.json" with {type:"json"};
+
+const require = createRequire(import.meta.url);
 
 /**
  * Clean all generated folder
@@ -17,17 +21,47 @@ function cleanDirs(){
   * Compile typescript files with version injection
   * */
 const compileTs = async () => {
+  const plugins = [{
+    name: 'bundle-slds-shared-utils',
+    setup(build) {
+      // Resolve the slds-shared-utils package root directory
+      try {
+        const packageJsonPath = require.resolve('slds-shared-utils/package.json');
+        const packageRoot = dirname(packageJsonPath);
+        
+        // Mark slds-shared-utils as non-external so it gets bundled
+        build.onResolve({ filter: /^slds-shared-utils/ }, args => {
+          // Handle subpath imports like 'slds-shared-utils/submodule'
+          const subpath = args.path.replace(/^slds-shared-utils\/?/, '');
+          
+          let resolvedPath;
+          if (subpath) {
+            // If there's a subpath, resolve it directly
+            resolvedPath = resolve(packageRoot, 'src', subpath + '.ts');
+          } else {
+            // If it's just 'slds-shared-utils', resolve to index
+            resolvedPath = resolve(packageRoot, 'src', 'index.ts');
+          }
+          
+          return {
+            path: resolvedPath,
+            external: false
+          };
+        });
+      } catch (error) {
+        console.warn('Could not resolve slds-shared-utils for bundling:', error.message);
+      }
+    }
+  }];
+
   await esbuild.build({
     entryPoints: ["./src/**/*.ts"],
     bundle: true,
     outdir: "build",
     platform: "node",
     format: "cjs",
-    preserveSymlinks: false, // Follow symlinks and bundle workspace packages
-    absWorkingDir: process.cwd(), // Set working directory for resolution
-    nodePaths: ["../../node_modules"], // Help find workspace packages
-    metafile: true, // Generate metadata for debugging
-    external: ["@html-eslint/parser", "@html-eslint/eslint-plugin", "@eslint/css", "@salesforce-ux/sds-metadata"], // External deps but bundle slds-shared-utils and chroma-js for independence
+    packages: 'external', // Externalize all node_modules by default
+    plugins, // Apply our custom bundling plugin
     sourcemap: process.env.NODE_ENV !== 'production',
     define: {
       'process.env.PLUGIN_VERSION': `"${pkg.version}"`

--- a/packages/stylelint-plugin-slds/gulpfile.js
+++ b/packages/stylelint-plugin-slds/gulpfile.js
@@ -3,7 +3,10 @@ import { esbuildPluginFilePathExtensions } from "esbuild-plugin-file-path-extens
 import { series, watch } from 'gulp';
 import { task } from "gulp-execa";
 import { rimraf } from 'rimraf';
+import { dirname, resolve } from 'path';
+import { createRequire } from 'module';
 
+const require = createRequire(import.meta.url);
 const ENABLE_SOURCE_MAPS = process.env.CLI_BUILD_MODE!=='release';
 
 /**
@@ -18,23 +21,50 @@ function cleanDirs(){
   * Compile typescript files
   * */ 
 const compileTs = async ()=>{
+  const plugins = [{
+    name: 'bundle-slds-shared-utils',
+    setup(build) {
+      // Resolve the slds-shared-utils package root directory
+      try {
+        const packageJsonPath = require.resolve('slds-shared-utils/package.json');
+        const packageRoot = dirname(packageJsonPath);
+        
+        // Mark slds-shared-utils as non-external so it gets bundled
+        build.onResolve({ filter: /^slds-shared-utils/ }, args => {
+          // Handle subpath imports like 'slds-shared-utils/submodule'
+          const subpath = args.path.replace(/^slds-shared-utils\/?/, '');
+          
+          let resolvedPath;
+          if (subpath) {
+            // If there's a subpath, resolve it directly
+            resolvedPath = resolve(packageRoot, 'src', subpath + '.ts');
+          } else {
+            // If it's just 'slds-shared-utils', resolve to index
+            resolvedPath = resolve(packageRoot, 'src', 'index.ts');
+          }
+          
+          return {
+            path: resolvedPath,
+            external: false
+          };
+        });
+      } catch (error) {
+        console.warn('Could not resolve slds-shared-utils for bundling:', error.message);
+      }
+    }
+  }, esbuildPluginFilePathExtensions({
+    esmExtension:"js"
+  })];
+
   await esbuild.build({
     entryPoints: ["./src/**/*.ts"],
     bundle:true,
     outdir:"build",
     platform: "node",
     format: "esm",
-    preserveSymlinks: false, // Follow symlinks and bundle workspace packages
-    absWorkingDir: process.cwd(), // Set working directory for resolution
-    nodePaths: ["../../node_modules"], // Help find workspace packages
-    metafile: true,
-    minify: false,
-    treeShaking: true,
-    external: ["stylelint", "postcss", "postcss-selector-parser", "@salesforce-ux/sds-metadata"], // External deps for stylelint plugin but bundle slds-shared-utils and postcss-value-parser
+    packages: 'external', // Externalize all node_modules by default
     sourcemap: ENABLE_SOURCE_MAPS,
-    plugins:[esbuildPluginFilePathExtensions({
-      esmExtension:"js"
-    })]
+    plugins // Apply our custom bundling plugin
   })
 };
 


### PR DESCRIPTION

<img width="1698" height="1080" alt="Screenshot 2025-07-22 at 4 49 34 PM" src="https://github.com/user-attachments/assets/f2fe6ba3-6dba-425f-9cb8-c46cb6f1a56c" />
 
 tested using tarball, working fine
 
 The implementation follows the exact same pattern as PR #220 and successfully enables you to retain packages: 'external' while ensuring slds-shared-utils gets bundled correctly