### PR TITLE
fix: corrected hardcoded value usage rule

### DIFF
--- a/demo/uplift-bugs.css
+++ b/demo/uplift-bugs.css
@@ -1,0 +1,77 @@
+.wrapper {
+  background: white;
+}
+
+.wrapper {
+  outline: 1px solid red;
+}
+
+.wrapper {
+  outline-width: 2px;
+}
+
+.wrapper {
+  padding: 4px 4px 2px 4px;
+  margin: 4px 4px 2px 4px;
+}
+
+.wrapper {
+  border-color: #001639 #001639 #001639 #001639;
+}
+
+.wrapper {
+  border-top-color: #001639;
+}
+
+.wrapper {
+  --slds-s-link-shadow-focus: 0 0 0 2px var(--slds-g-color-surface-1), 0 0 0 3px var(--slds-g-color-brand-base-40);
+}
+
+
+ .wrapper {
+  top: .25rem;
+  margin-bottom: 12px;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  margin-left: 12px;
+  margin-right: 12px;
+  margin-top: 12px;
+  margin-bottom: 12px;
+  border-left-width: 12px;
+  border-right-width: 12px;
+  border-top-width: 12px;
+  border-bottom-width: 12px;
+  border-inline-start-width: 12px;
+  border-inline-end-width: 12px;
+  border-block-start-width: 12px;
+  border-block-end-width: 12px;
+  border-left-color: #001639;
+  border-right-color: #001639;
+  border-top-color: #001639;
+  border-bottom-color: #001639;
+  border-inline-start-color: #001639;
+  border-inline-end-color: #001639;
+  border-block-start-color: #001639;
+  border-block-end-color: #001639;
+  margin: 0 .5rem .5rem 0;
+  padding: 1rem .5rem;
+  border-radius: 100%;
+  border-top-left-radius: 100%;
+  border-top-right-radius: 100%;
+  border-bottom-right-radius: 100%;
+  border-bottom-left-radius: 100%;
+  border-start-start-radius: 100%;
+  border-start-end-radius: 100%;
+  border-end-start-radius: 100%;
+  border-end-end-radius: 100%;
+  height: 24px;
+  width: 24px;
+  min-width: 24px;
+  max-width: 24px;
+  min-height: 24px;
+  max-height: 24px;  
+  width: 10rem;   
+  width: 2px;
+ }

--- a/packages/eslint-plugin-slds/package.json
+++ b/packages/eslint-plugin-slds/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@html-eslint/eslint-plugin": "^0.34.0",
     "@html-eslint/parser": "^0.34.0",
-    "@salesforce-ux/sds-metadata": "^0.3.2"
+    "@salesforce-ux/sds-metadata": "^0.3.3"
   },
   "peerDependencies": {
     "eslint": "^8.0.0 || ^9.0.0"

--- a/packages/stylelint-plugin-slds/package.json
+++ b/packages/stylelint-plugin-slds/package.json
@@ -16,7 +16,7 @@
     "dev": "gulp dev"
   },
   "dependencies": {
-    "@salesforce-ux/sds-metadata": "^0.3.2",
+    "@salesforce-ux/sds-metadata": "^0.3.3",
     "chroma-js": "^3.1.2"
   },
   "devDependencies": {

--- a/packages/stylelint-plugin-slds/src/rules/no-hardcoded-value/noHardcodedValue.rule.ts
+++ b/packages/stylelint-plugin-slds/src/rules/no-hardcoded-value/noHardcodedValue.rule.ts
@@ -5,12 +5,11 @@ import ruleMetadata from '../../utils/rulesMetadata';
 import { isTargetProperty } from '../../utils/prop-utills';
 import { handleBoxShadow } from './handlers/boxShadowHandler';
 import { handleColorProps } from './handlers/colorHandler';
-import { handleDensityPropForNode } from './handlers/densityHandler';
+import { handleDensityProps } from './handlers/densityHandler';
 import { toRuleMessages } from '../../utils/rule-message-utils';
 import { colorProperties, densificationProperties, matchesCssProperty } from '../../utils/property-matcher';
 import type { ValueToStylingHooksMapping } from '@salesforce-ux/sds-metadata';
 import { handleFontProps } from './handlers/fontHandler';
-import { forEachDensifyValue } from '../../utils/density-utils';
 import { isFontProperty } from '../../utils/fontValueParser';
 import { isRuleEnabled } from '../../utils/rule-utils';
 
@@ -80,20 +79,30 @@ export const createNoHardcodedValueRule = (
             reportProps,
             messages
           );
-        } else if (isColorProp) {
-          handleColorProps(
-            decl,
-            parsedValue,
-            cssValueStartIndex,
-            supportedStylinghooks,
-            cssProperty,
-            reportProps,
-            messages
-          );
-        } else if (isDensiProp) {
-          forEachDensifyValue(parsedValue, (node) => {
-            handleDensityPropForNode(decl, node, node.value, cssValueStartIndex, supportedStylinghooks, cssProperty, reportProps, messages);
-          });
+        } else {
+          if (isColorProp) {
+            handleColorProps(
+              decl,
+              parsedValue,
+              cssValueStartIndex,
+              supportedStylinghooks,
+              cssProperty,
+              reportProps,
+              messages
+            );
+          }
+          
+          if (isDensiProp) {
+            handleDensityProps(
+              decl,
+              parsedValue,
+              cssValueStartIndex,
+              supportedStylinghooks,
+              cssProperty,
+              reportProps,
+              messages
+            );
+          }
         }
       });
     };

--- a/packages/stylelint-plugin-slds/src/utils/decl-utils.ts
+++ b/packages/stylelint-plugin-slds/src/utils/decl-utils.ts
@@ -79,3 +79,7 @@ export function isCommaDivision(node: valueParser.Node): boolean {
 export function isInsetKeyword(node: valueParser.Node): boolean {
   return node.type === 'word' && node.value === 'inset';
 }
+
+export function isSameNode(node1: valueParser.Node, node2: valueParser.Node): boolean {
+  return node1.type === node2.type && node1.value === node2.value && node1.sourceIndex === node2.sourceIndex && node1.sourceEndIndex === node2.sourceEndIndex;
+}

--- a/packages/stylelint-plugin-slds/src/utils/property-matcher.ts
+++ b/packages/stylelint-plugin-slds/src/utils/property-matcher.ts
@@ -16,6 +16,48 @@ export function matchesCssProperty(
   });
 }
 
+// Directions & Corners
+const DIRECTION_VALUES = '(?:top|right|bottom|left|inline|block|inline-start|inline-end|start|end|block-start|block-end)';
+const CORNER_VALUES = '(?:top-left|top-right|bottom-right|bottom-left|start-start|start-end|end-start|end-end)';
+const INSET_VALUES = '(?:inline|block|inline-start|inline-end|block-start|block-end)';
+
+
+// Pre-compiled regex patterns for better performance
+const BORDER_COLOR_REGEX = new RegExp(`^border(?:-${DIRECTION_VALUES})?-color$`);
+const BORDER_WIDTH_REGEX = new RegExp(`^border(?:-${DIRECTION_VALUES})?-width$`);
+const MARGIN_REGEX = new RegExp(`^margin(?:-${DIRECTION_VALUES})?$`);
+const PADDING_REGEX = new RegExp(`^padding(?:-${DIRECTION_VALUES})?$`);
+const BORDER_RADIUS_REGEX = new RegExp(`^border(?:-${CORNER_VALUES})?-radius$`);
+const INSET_REGEX = new RegExp(`^inset(?:-${INSET_VALUES})?$`);
+
+export function isBorderColorProperty(cssProperty: string): boolean {
+  return BORDER_COLOR_REGEX.test(cssProperty);
+}
+
+export function isBorderWidthProperty(cssProperty: string): boolean {
+  return BORDER_WIDTH_REGEX.test(cssProperty);
+}
+
+export function isMarginProperty(cssProperty: string): boolean {
+  return MARGIN_REGEX.test(cssProperty);
+}
+
+export function isPaddingProperty(cssProperty: string): boolean {
+  return PADDING_REGEX.test(cssProperty);
+}
+
+export function isBorderRadius(cssProperty: string): boolean {
+  return BORDER_RADIUS_REGEX.test(cssProperty);
+}
+
+export function isDimensionProperty(cssProperty: string): boolean {
+  return ['width', 'height', 'min-width', 'max-width', 'min-height', 'max-height'].includes(cssProperty);
+}
+
+export function isInsetProperty(cssProperty: string): boolean {
+  return INSET_REGEX.test(cssProperty);
+}
+
 export const colorProperties = [
   'color',
   'fill',
@@ -23,6 +65,7 @@ export const colorProperties = [
   'background-color',
   'stroke',
   'border*-color',
+  'outline',
   'outline-color',
 ];
 
@@ -32,8 +75,39 @@ export const densificationProperties = [
   'padding*',
   'width',
   'height',
+  'min-width',
+  'max-width',
+  'min-height',
+  'max-height',
+  'inset',
   'top',
   'right',
   'left',
-  'bottom'
+  'bottom',
+  'outline',
+  'outline-width'
 ]; 
+
+export function resolvePropertyToMatch(cssProperty:string){
+  const propertyToMatch = cssProperty.toLowerCase();
+  if(propertyToMatch === 'outline' || propertyToMatch === 'outline-width' || isBorderWidthProperty(propertyToMatch)){
+    return 'border-width';
+  } else if(isMarginProperty(propertyToMatch)){
+    return 'margin';
+  } else if(isPaddingProperty(propertyToMatch)){
+    return 'padding';
+  } else if(isBorderRadius(propertyToMatch)){
+    return 'border-radius';
+  } else if(isDimensionProperty(propertyToMatch)){
+    // Stylinghooks includes only width as property to match, for all other dimensions we need to match width
+    return 'width';
+  } else if(isInsetProperty(propertyToMatch)){
+    // Stylinghooks includes only top/left/right/bottom as property to match, for all other insets we need to match top
+    return 'top';
+  } else if(cssProperty === 'background' || cssProperty === 'background-color'){
+    return 'background-color';
+  } else if(cssProperty === 'outline' || cssProperty === 'outline-color' || isBorderColorProperty(cssProperty)){
+    return 'border-color';
+  }
+  return propertyToMatch;
+}

--- a/packages/stylelint-plugin-slds/src/utils/value-utils.ts
+++ b/packages/stylelint-plugin-slds/src/utils/value-utils.ts
@@ -38,23 +38,39 @@ export function isGlobalValue(value: string): boolean {
     return value === 'initial' || value === 'inherit' || value === 'unset' || value === 'revert' || value === 'revert-layer';
   }
 
+export type ParsedUnitValue = {
+  unit: 'px' | 'rem';
+  number: number;
+} | null;
 
+export function parseUnitValue(value: string): ParsedUnitValue {
+  const parsedValue = valueParser.unit(value);
+  if(!parsedValue){
+    return null;
+  }
+  return {
+    unit: parsedValue.unit as 'px' | 'rem',
+    number: parseFloat(parsedValue.number)
+  };
+}
 
-export function toAlternateUnitValue(value: string): string {
-    const parsedValue = valueParser.unit(value);
-    const unitType = parsedValue && parsedValue.unit;
-    const numberVal = parsedValue ? Number(parsedValue.number) : 0;
-    let alternateValue = null;
+export function toAlternateUnitValue(numberVal: number, unitType: 'px' | 'rem'): ParsedUnitValue {
     if (unitType === 'px') {
       let floatValue = parseFloat(`${numberVal / 16}`);
       if (!isNaN(floatValue)) {
-        alternateValue = `${parseFloat(floatValue.toFixed(4))}rem`;
+        return {
+          unit: 'rem',
+          number: parseFloat(floatValue.toFixed(4))
+        }
       }
     } else if (unitType === 'rem') {
       const intValue = parseInt(`${numberVal * 16}`);
       if (!isNaN(intValue)) {
-        alternateValue = `${intValue}px`;
+        return {
+          unit: 'px',
+          number: intValue
+        }
       }
     }
-    return alternateValue;
+    return null;
 }

--- a/packages/stylelint-plugin-slds/tests/utils/property-matcher.spec.ts
+++ b/packages/stylelint-plugin-slds/tests/utils/property-matcher.spec.ts
@@ -1,0 +1,330 @@
+import {
+  matchesCssProperty,
+  isBorderColorProperty,
+  isBorderWidthProperty,
+  isMarginProperty,
+  isPaddingProperty,
+  isBorderRadius,
+  isDimensionProperty,
+  isInsetProperty,
+  colorProperties,
+  densificationProperties,
+  resolvePropertyToMatch
+} from '../../src/utils/property-matcher';
+
+describe('property-matcher', () => {
+  describe('matchesCssProperty', () => {
+    it('should match exact property names', () => {
+      const hookProperties = ['color', 'background-color', 'border-width'];
+      expect(matchesCssProperty(hookProperties, 'color')).toBe(true);
+      expect(matchesCssProperty(hookProperties, 'background-color')).toBe(true);
+      expect(matchesCssProperty(hookProperties, 'border-width')).toBe(true);
+    });
+
+    it('should match wildcard patterns', () => {
+      const hookProperties = ['border*-color', 'margin*', 'padding*'];
+      expect(matchesCssProperty(hookProperties, 'border-color')).toBe(true);
+      expect(matchesCssProperty(hookProperties, 'border-top-color')).toBe(true);
+      expect(matchesCssProperty(hookProperties, 'border-right-color')).toBe(true);
+      expect(matchesCssProperty(hookProperties, 'margin')).toBe(true);
+      expect(matchesCssProperty(hookProperties, 'margin-top')).toBe(true);
+      expect(matchesCssProperty(hookProperties, 'padding')).toBe(true);
+      expect(matchesCssProperty(hookProperties, 'padding-bottom')).toBe(true);
+    });
+
+    it('should not match non-matching properties', () => {
+      const hookProperties = ['border*-color', 'margin*'];
+      expect(matchesCssProperty(hookProperties, 'background-color')).toBe(false);
+      expect(matchesCssProperty(hookProperties, 'padding')).toBe(false);
+      expect(matchesCssProperty(hookProperties, 'border-width')).toBe(false);
+    });
+
+    it('should handle empty hook properties array', () => {
+      const hookProperties: string[] = [];
+      expect(matchesCssProperty(hookProperties, 'color')).toBe(false);
+    });
+
+    it('should handle complex wildcard patterns', () => {
+      const hookProperties = ['border-*-color', 'margin-*', '*width'];
+      expect(matchesCssProperty(hookProperties, 'border-top-color')).toBe(true);
+      expect(matchesCssProperty(hookProperties, 'margin-top')).toBe(true);
+      expect(matchesCssProperty(hookProperties, 'width')).toBe(true);
+      expect(matchesCssProperty(hookProperties, 'border-width')).toBe(true);
+    });
+  });
+
+  describe('isBorderColorProperty', () => {
+    it('should match basic border color properties', () => {
+      expect(isBorderColorProperty('border-color')).toBe(true);
+      expect(isBorderColorProperty('border-top-color')).toBe(true);
+      expect(isBorderColorProperty('border-right-color')).toBe(true);
+      expect(isBorderColorProperty('border-bottom-color')).toBe(true);
+      expect(isBorderColorProperty('border-left-color')).toBe(true);
+    });
+
+    it('should match logical border color properties', () => {
+      expect(isBorderColorProperty('border-inline-color')).toBe(true);
+      expect(isBorderColorProperty('border-block-color')).toBe(true);
+      expect(isBorderColorProperty('border-inline-start-color')).toBe(true);
+      expect(isBorderColorProperty('border-inline-end-color')).toBe(true);
+      expect(isBorderColorProperty('border-block-start-color')).toBe(true);
+      expect(isBorderColorProperty('border-block-end-color')).toBe(true);
+      expect(isBorderColorProperty('border-start-color')).toBe(true);
+      expect(isBorderColorProperty('border-end-color')).toBe(true);
+    });
+
+    it('should not match non-border color properties', () => {
+      expect(isBorderColorProperty('color')).toBe(false);
+      expect(isBorderColorProperty('background-color')).toBe(false);
+      expect(isBorderColorProperty('border-width')).toBe(false);
+      expect(isBorderColorProperty('border-style')).toBe(false);
+    });
+  });
+
+  describe('isBorderWidthProperty', () => {
+    it('should match basic border width properties', () => {
+      expect(isBorderWidthProperty('border-width')).toBe(true);
+      expect(isBorderWidthProperty('border-top-width')).toBe(true);
+      expect(isBorderWidthProperty('border-right-width')).toBe(true);
+      expect(isBorderWidthProperty('border-bottom-width')).toBe(true);
+      expect(isBorderWidthProperty('border-left-width')).toBe(true);
+    });
+
+    it('should match logical border width properties', () => {
+      expect(isBorderWidthProperty('border-inline-width')).toBe(true);
+      expect(isBorderWidthProperty('border-block-width')).toBe(true);
+      expect(isBorderWidthProperty('border-inline-start-width')).toBe(true);
+      expect(isBorderWidthProperty('border-inline-end-width')).toBe(true);
+      expect(isBorderWidthProperty('border-block-start-width')).toBe(true);
+      expect(isBorderWidthProperty('border-block-end-width')).toBe(true);
+      expect(isBorderWidthProperty('border-start-width')).toBe(true);
+      expect(isBorderWidthProperty('border-end-width')).toBe(true);
+    });
+
+    it('should not match non-border width properties', () => {
+      expect(isBorderWidthProperty('border-color')).toBe(false);
+      expect(isBorderWidthProperty('border-style')).toBe(false);
+      expect(isBorderWidthProperty('width')).toBe(false);
+    });
+  });
+
+  describe('isMarginProperty', () => {
+    it('should match basic margin properties', () => {
+      expect(isMarginProperty('margin')).toBe(true);
+      expect(isMarginProperty('margin-top')).toBe(true);
+      expect(isMarginProperty('margin-right')).toBe(true);
+      expect(isMarginProperty('margin-bottom')).toBe(true);
+      expect(isMarginProperty('margin-left')).toBe(true);
+    });
+
+    it('should match logical margin properties', () => {
+      expect(isMarginProperty('margin-inline')).toBe(true);
+      expect(isMarginProperty('margin-block')).toBe(true);
+      expect(isMarginProperty('margin-inline-start')).toBe(true);
+      expect(isMarginProperty('margin-inline-end')).toBe(true);
+      expect(isMarginProperty('margin-block-start')).toBe(true);
+      expect(isMarginProperty('margin-block-end')).toBe(true);
+      expect(isMarginProperty('margin-start')).toBe(true);
+      expect(isMarginProperty('margin-end')).toBe(true);
+    });
+
+    it('should not match non-margin properties', () => {
+      expect(isMarginProperty('padding')).toBe(false);
+      expect(isMarginProperty('border-width')).toBe(false);
+      expect(isMarginProperty('color')).toBe(false);
+    });
+  });
+
+  describe('isPaddingProperty', () => {
+    it('should match basic padding properties', () => {
+      expect(isPaddingProperty('padding')).toBe(true);
+      expect(isPaddingProperty('padding-top')).toBe(true);
+      expect(isPaddingProperty('padding-right')).toBe(true);
+      expect(isPaddingProperty('padding-bottom')).toBe(true);
+      expect(isPaddingProperty('padding-left')).toBe(true);
+    });
+
+    it('should match logical padding properties', () => {
+      expect(isPaddingProperty('padding-inline')).toBe(true);
+      expect(isPaddingProperty('padding-block')).toBe(true);
+      expect(isPaddingProperty('padding-inline-start')).toBe(true);
+      expect(isPaddingProperty('padding-inline-end')).toBe(true);
+      expect(isPaddingProperty('padding-block-start')).toBe(true);
+      expect(isPaddingProperty('padding-block-end')).toBe(true);
+      expect(isPaddingProperty('padding-start')).toBe(true);
+      expect(isPaddingProperty('padding-end')).toBe(true);
+    });
+
+    it('should not match non-padding properties', () => {
+      expect(isPaddingProperty('margin')).toBe(false);
+      expect(isPaddingProperty('border-width')).toBe(false);
+      expect(isPaddingProperty('color')).toBe(false);
+    });
+  });
+
+  describe('isBorderRadius', () => {
+    it('should match basic border radius properties', () => {
+      expect(isBorderRadius('border-radius')).toBe(true);
+      expect(isBorderRadius('border-top-left-radius')).toBe(true);
+      expect(isBorderRadius('border-top-right-radius')).toBe(true);
+      expect(isBorderRadius('border-bottom-right-radius')).toBe(true);
+      expect(isBorderRadius('border-bottom-left-radius')).toBe(true);
+    });
+
+    it('should match logical border radius properties', () => {
+      expect(isBorderRadius('border-start-start-radius')).toBe(true);
+      expect(isBorderRadius('border-start-end-radius')).toBe(true);
+      expect(isBorderRadius('border-end-start-radius')).toBe(true);
+      expect(isBorderRadius('border-end-end-radius')).toBe(true);
+    });
+
+    it('should not match non-border radius properties', () => {
+      expect(isBorderRadius('border-width')).toBe(false);
+      expect(isBorderRadius('border-color')).toBe(false);
+      expect(isBorderRadius('radius')).toBe(false);
+    });
+  });
+
+  describe('isDimensionProperty', () => {
+    it('should match dimension properties', () => {
+      expect(isDimensionProperty('width')).toBe(true);
+      expect(isDimensionProperty('height')).toBe(true);
+      expect(isDimensionProperty('min-width')).toBe(true);
+      expect(isDimensionProperty('max-width')).toBe(true);
+      expect(isDimensionProperty('min-height')).toBe(true);
+      expect(isDimensionProperty('max-height')).toBe(true);
+    });
+
+    it('should not match non-dimension properties', () => {
+      expect(isDimensionProperty('color')).toBe(false);
+      expect(isDimensionProperty('margin')).toBe(false);
+      expect(isDimensionProperty('padding')).toBe(false);
+      expect(isDimensionProperty('border-width')).toBe(false);
+    });
+  });
+
+  describe('isInsetProperty', () => {
+    it('should match basic inset properties', () => {
+      expect(isInsetProperty('inset')).toBe(true);
+      expect(isInsetProperty('inset-inline')).toBe(true);
+      expect(isInsetProperty('inset-block')).toBe(true);
+      expect(isInsetProperty('inset-inline-start')).toBe(true);
+      expect(isInsetProperty('inset-inline-end')).toBe(true);
+      expect(isInsetProperty('inset-block-start')).toBe(true);
+      expect(isInsetProperty('inset-block-end')).toBe(true);
+    });
+
+    it('should not match non-inset properties', () => {
+      expect(isInsetProperty('top')).toBe(false);
+      expect(isInsetProperty('right')).toBe(false);
+      expect(isInsetProperty('bottom')).toBe(false);
+      expect(isInsetProperty('left')).toBe(false);
+      expect(isInsetProperty('margin')).toBe(false);
+    });
+  });
+
+  describe('colorProperties', () => {
+    it('should contain expected color properties', () => {
+      expect(colorProperties).toContain('color');
+      expect(colorProperties).toContain('fill');
+      expect(colorProperties).toContain('background');
+      expect(colorProperties).toContain('background-color');
+      expect(colorProperties).toContain('stroke');
+      expect(colorProperties).toContain('border*-color');
+      expect(colorProperties).toContain('outline');
+      expect(colorProperties).toContain('outline-color');
+    });
+
+    it('should be an array', () => {
+      expect(Array.isArray(colorProperties)).toBe(true);
+    });
+  });
+
+  describe('densificationProperties', () => {
+    it('should contain expected densification properties', () => {
+      expect(densificationProperties).toContain('border*');
+      expect(densificationProperties).toContain('margin*');
+      expect(densificationProperties).toContain('padding*');
+      expect(densificationProperties).toContain('width');
+      expect(densificationProperties).toContain('height');
+      expect(densificationProperties).toContain('min-width');
+      expect(densificationProperties).toContain('max-width');
+      expect(densificationProperties).toContain('min-height');
+      expect(densificationProperties).toContain('max-height');
+      expect(densificationProperties).toContain('inset');
+      expect(densificationProperties).toContain('top');
+      expect(densificationProperties).toContain('right');
+      expect(densificationProperties).toContain('left');
+      expect(densificationProperties).toContain('bottom');
+      expect(densificationProperties).toContain('outline');
+      expect(densificationProperties).toContain('outline-width');
+    });
+
+    it('should be an array', () => {
+      expect(Array.isArray(densificationProperties)).toBe(true);
+    });
+  });
+
+  describe('resolvePropertyToMatch', () => {
+    it('should resolve outline properties to border-width', () => {
+      expect(resolvePropertyToMatch('outline')).toBe('border-width');
+      expect(resolvePropertyToMatch('outline-width')).toBe('border-width');
+    });
+
+    it('should resolve border width properties to border-width', () => {
+      expect(resolvePropertyToMatch('border-width')).toBe('border-width');
+      expect(resolvePropertyToMatch('border-top-width')).toBe('border-width');
+      expect(resolvePropertyToMatch('border-right-width')).toBe('border-width');
+    });
+
+    it('should resolve margin properties to margin', () => {
+      expect(resolvePropertyToMatch('margin')).toBe('margin');
+      expect(resolvePropertyToMatch('margin-top')).toBe('margin');
+      expect(resolvePropertyToMatch('margin-right')).toBe('margin');
+    });
+
+    it('should resolve padding properties to padding', () => {
+      expect(resolvePropertyToMatch('padding')).toBe('padding');
+      expect(resolvePropertyToMatch('padding-top')).toBe('padding');
+      expect(resolvePropertyToMatch('padding-right')).toBe('padding');
+    });
+
+    it('should resolve border radius properties to border-radius', () => {
+      expect(resolvePropertyToMatch('border-radius')).toBe('border-radius');
+      expect(resolvePropertyToMatch('border-top-left-radius')).toBe('border-radius');
+      expect(resolvePropertyToMatch('border-top-right-radius')).toBe('border-radius');
+    });
+
+    it('should resolve dimension properties to width', () => {
+      expect(resolvePropertyToMatch('width')).toBe('width');
+      expect(resolvePropertyToMatch('height')).toBe('width');
+      expect(resolvePropertyToMatch('min-width')).toBe('width');
+      expect(resolvePropertyToMatch('max-width')).toBe('width');
+      expect(resolvePropertyToMatch('min-height')).toBe('width');
+      expect(resolvePropertyToMatch('max-height')).toBe('width');
+    });
+
+    it('should resolve inset properties to top', () => {
+      expect(resolvePropertyToMatch('inset')).toBe('top');
+      expect(resolvePropertyToMatch('inset-inline')).toBe('top');
+      expect(resolvePropertyToMatch('inset-block')).toBe('top');
+      expect(resolvePropertyToMatch('inset-inline-start')).toBe('top');
+      expect(resolvePropertyToMatch('inset-inline-end')).toBe('top');
+      expect(resolvePropertyToMatch('inset-block-start')).toBe('top');
+      expect(resolvePropertyToMatch('inset-block-end')).toBe('top');
+    });
+
+    it('should return the property as-is for other properties', () => {
+      expect(resolvePropertyToMatch('color')).toBe('color');
+      expect(resolvePropertyToMatch('background-color')).toBe('background-color');
+      expect(resolvePropertyToMatch('font-size')).toBe('font-size');
+      expect(resolvePropertyToMatch('display')).toBe('display');
+    });
+
+    it('should handle case-insensitive input', () => {
+      expect(resolvePropertyToMatch('OUTLINE')).toBe('border-width');
+      expect(resolvePropertyToMatch('Margin')).toBe('margin');
+      expect(resolvePropertyToMatch('PADDING')).toBe('padding');
+    });
+  });
+}); 

--- a/packages/stylelint-plugin-slds/tests/utils/styling-hook-utils.spec.ts
+++ b/packages/stylelint-plugin-slds/tests/utils/styling-hook-utils.spec.ts
@@ -1,0 +1,261 @@
+import { getStylingHooksForDensityValue } from '../../src/utils/styling-hook-utils';
+import type { ValueToStylingHookEntry, ValueToStylingHooksMapping } from '@salesforce-ux/sds-metadata';
+
+describe('styling-hook-utils', () => {
+  describe('getStylingHooksForDensityValue', () => {
+    const mockStylingHooks: ValueToStylingHooksMapping = {
+      '16px': [
+        {
+          name: 'slds-spacing-small',
+          properties: ['margin', 'padding', 'width', 'height']
+        },
+        {
+          name: 'slds-spacing-medium',
+          properties: ['margin', 'padding']
+        }
+      ],
+      '1rem': [
+        {
+          name: 'slds-spacing-small-rem',
+          properties: ['margin', 'padding', 'width', 'height']
+        }
+      ],
+      '32px': [
+        {
+          name: 'slds-spacing-large',
+          properties: ['margin', 'padding']
+        }
+      ],
+      '2rem': [
+        {
+          name: 'slds-spacing-large-rem',
+          properties: ['margin', 'padding']
+        }
+      ]
+    };
+
+    it('should return matching hooks for exact px value match', () => {
+      const result = getStylingHooksForDensityValue('16px', mockStylingHooks, 'margin');
+      expect(result).toEqual(['slds-spacing-small', 'slds-spacing-medium', 'slds-spacing-small-rem']);
+    });
+
+    it('should return matching hooks for exact rem value match', () => {
+      const result = getStylingHooksForDensityValue('1rem', mockStylingHooks, 'padding');
+      expect(result).toEqual(['slds-spacing-small', 'slds-spacing-medium', 'slds-spacing-small-rem']);
+    });
+
+    it('should return matching hooks for px to rem conversion', () => {
+      const result = getStylingHooksForDensityValue('16px', mockStylingHooks, 'width');
+      expect(result).toEqual(['slds-spacing-small', 'slds-spacing-small-rem']);
+    });
+
+    it('should return matching hooks for rem to px conversion', () => {
+      const result = getStylingHooksForDensityValue('1rem', mockStylingHooks, 'height');
+      expect(result).toEqual(['slds-spacing-small', 'slds-spacing-small-rem']);
+    });
+
+    it('should filter hooks by CSS property', () => {
+      const result = getStylingHooksForDensityValue('16px', mockStylingHooks, 'width');
+      expect(result).toEqual(['slds-spacing-small', 'slds-spacing-small-rem']);
+      // Should not include slds-spacing-medium since it doesn't include 'width'
+    });
+
+    it('should return empty array when no matching value found', () => {
+      const result = getStylingHooksForDensityValue('8px', mockStylingHooks, 'margin');
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when no hooks match the CSS property', () => {
+      const result = getStylingHooksForDensityValue('16px', mockStylingHooks, 'color');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle empty styling hooks mapping', () => {
+      const emptyMapping: ValueToStylingHooksMapping = {};
+      const result = getStylingHooksForDensityValue('16px', emptyMapping, 'margin');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle invalid value format', () => {
+      expect(() => {
+        getStylingHooksForDensityValue('invalid', mockStylingHooks, 'margin');
+      }).toThrow();
+    });
+
+    it('should handle empty value', () => {
+      expect(() => {
+        getStylingHooksForDensityValue('', mockStylingHooks, 'margin');
+      }).toThrow();
+    });
+
+    it('should handle zero values', () => {
+      const zeroMapping: ValueToStylingHooksMapping = {
+        '0px': [
+          {
+            name: 'slds-spacing-none',
+            properties: ['margin', 'padding']
+          }
+        ]
+      };
+      const result = getStylingHooksForDensityValue('0px', zeroMapping, 'margin');
+      expect(result).toEqual(['slds-spacing-none']);
+    });
+
+    it('should handle decimal values', () => {
+      const decimalMapping: ValueToStylingHooksMapping = {
+        '0.5rem': [
+          {
+            name: 'slds-spacing-tiny',
+            properties: ['margin', 'padding']
+          }
+        ]
+      };
+      const result = getStylingHooksForDensityValue('0.5rem', decimalMapping, 'margin');
+      expect(result).toEqual(['slds-spacing-tiny']);
+    });
+
+    it('should handle multiple hooks with same value but different properties', () => {
+      const multiHookMapping: ValueToStylingHooksMapping = {
+        '16px': [
+          {
+            name: 'slds-spacing-small',
+            properties: ['margin', 'padding']
+          },
+          {
+            name: 'slds-spacing-small-dimensions',
+            properties: ['width', 'height']
+          },
+          {
+            name: 'slds-spacing-small-all',
+            properties: ['margin', 'padding', 'width', 'height']
+          }
+        ]
+      };
+      const result = getStylingHooksForDensityValue('16px', multiHookMapping, 'width');
+      expect(result).toEqual(['slds-spacing-small-dimensions', 'slds-spacing-small-all']);
+    });
+
+    it('should handle case-sensitive CSS property matching', () => {
+      const result = getStylingHooksForDensityValue('16px', mockStylingHooks, 'MARGIN');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle complex unit conversions', () => {
+      // Test that 16px matches 1rem (16/16 = 1)
+      const conversionMapping: ValueToStylingHooksMapping = {
+        '1rem': [
+          {
+            name: 'slds-spacing-small-rem',
+            properties: ['margin', 'padding']
+          }
+        ]
+      };
+      const result = getStylingHooksForDensityValue('16px', conversionMapping, 'margin');
+      expect(result).toEqual(['slds-spacing-small-rem']);
+    });
+
+    it('should handle reverse unit conversions', () => {
+      // Test that 1rem matches 16px (1*16 = 16)
+      const conversionMapping: ValueToStylingHooksMapping = {
+        '16px': [
+          {
+            name: 'slds-spacing-small',
+            properties: ['margin', 'padding']
+          }
+        ]
+      };
+      const result = getStylingHooksForDensityValue('1rem', conversionMapping, 'margin');
+      expect(result).toEqual(['slds-spacing-small']);
+    });
+
+    it('should handle non-convertible values', () => {
+      // Test values that don't convert cleanly between px and rem
+      const result = getStylingHooksForDensityValue('17px', mockStylingHooks, 'margin');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle hooks with empty properties array', () => {
+      const emptyPropsMapping: ValueToStylingHooksMapping = {
+        '16px': [
+          {
+            name: 'slds-spacing-small',
+            properties: []
+          }
+        ]
+      };
+      const result = getStylingHooksForDensityValue('16px', emptyPropsMapping, 'margin');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle hooks with null/undefined properties', () => {
+      const nullPropsMapping: ValueToStylingHooksMapping = {
+        '16px': [
+          {
+            name: 'slds-spacing-small',
+            properties: ['margin', 'padding']
+          } as ValueToStylingHookEntry
+        ]
+      };
+      const result = getStylingHooksForDensityValue('16px', nullPropsMapping, 'margin');
+      expect(result).toEqual(['slds-spacing-small']);
+    });
+
+    it('should handle very large values', () => {
+      const largeValueMapping: ValueToStylingHooksMapping = {
+        '1000px': [
+          {
+            name: 'slds-spacing-very-large',
+            properties: ['margin', 'padding']
+          }
+        ]
+      };
+      const result = getStylingHooksForDensityValue('1000px', largeValueMapping, 'margin');
+      expect(result).toEqual(['slds-spacing-very-large']);
+    });
+
+    it('should handle very small values', () => {
+      const smallValueMapping: ValueToStylingHooksMapping = {
+        '0.0625rem': [
+          {
+            name: 'slds-spacing-tiny',
+            properties: ['margin', 'padding']
+          }
+        ]
+      };
+      const result = getStylingHooksForDensityValue('0.0625rem', smallValueMapping, 'margin');
+      expect(result).toEqual(['slds-spacing-tiny']);
+    });
+
+    it('should handle negative values', () => {
+      const negativeValueMapping: ValueToStylingHooksMapping = {
+        '-16px': [
+          {
+            name: 'slds-spacing-negative',
+            properties: ['margin', 'padding']
+          }
+        ]
+      };
+      const result = getStylingHooksForDensityValue('-16px', negativeValueMapping, 'margin');
+      expect(result).toEqual(['slds-spacing-negative']);
+    });
+
+    it('should handle mixed unit types in the same mapping', () => {
+      const mixedMapping: ValueToStylingHooksMapping = {
+        '16px': [
+          {
+            name: 'slds-spacing-small-px',
+            properties: ['margin', 'padding']
+          }
+        ],
+        '1rem': [
+          {
+            name: 'slds-spacing-small-rem',
+            properties: ['margin', 'padding']
+          }
+        ]
+      };
+      const result = getStylingHooksForDensityValue('16px', mixedMapping, 'margin');
+      expect(result).toEqual(['slds-spacing-small-px', 'slds-spacing-small-rem']);
+    });
+  });
+}); 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,7 +1306,7 @@ __metadata:
   dependencies:
     "@html-eslint/eslint-plugin": "npm:^0.34.0"
     "@html-eslint/parser": "npm:^0.34.0"
-    "@salesforce-ux/sds-metadata": "npm:^0.3.2"
+    "@salesforce-ux/sds-metadata": "npm:^0.3.3"
     "@types/eslint": "npm:^8.56.0"
     "@types/jest": "npm:^29.5.14"
     jest: "npm:^29.7.0"
@@ -1319,10 +1319,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@salesforce-ux/sds-metadata@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "@salesforce-ux/sds-metadata@npm:0.3.2"
-  checksum: 10c0/bde4aa1dad6156b801523115534282c672aaaa17a9f0771f978d19452d4f28e36deebfe54a4ac728090fa9d1405a61945907e9e8e9546e3bc5ba247a5c48c342
+"@salesforce-ux/sds-metadata@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "@salesforce-ux/sds-metadata@npm:0.3.3"
+  checksum: 10c0/67cb2df69974c1337b0b2db421d357994dcc6517e432fa9dc8cdccd08abab9ef073399763dcd0f509c68d8a9f2406b2a082806bcaf6c4b304df5c29ab0537707
   languageName: node
   linkType: hard
 
@@ -1357,7 +1357,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@salesforce-ux/stylelint-plugin-slds@workspace:packages/stylelint-plugin-slds"
   dependencies:
-    "@salesforce-ux/sds-metadata": "npm:^0.3.2"
+    "@salesforce-ux/sds-metadata": "npm:^0.3.3"
     "@types/jest": "npm:^29.5.14"
     "@types/postcss-plugins": "npm:1.13.2"
     chroma-js: "npm:^3.1.2"


### PR DESCRIPTION
- Update @salesforce-ux/sds-metadata to version 0.3.3 in package dependencies 
- Add uplift-bugs.css for styling adjustments
- Refactor density and color handling in stylelint plugin, enhancing property matching and unit conversion utilities. 
- Add tests for property matcher and styling hook utilities.