### PR TITLE
fix: corrected BEM message and test cases

### DIFF
--- a/packages/stylelint-plugin-slds/src/utils/rules.ts
+++ b/packages/stylelint-plugin-slds/src/utils/rules.ts
@@ -5,6 +5,7 @@ const rulesMetadata = {
     severityLevel: "error",
     ruleDesc:
       "Replace BEM double-dash syntax in class names with single underscore syntax.",
+    errorMsg: "${oldValue} has been retired. Update it to the new name ${newValue}",  
   },
 
   "slds/modal-close-button-issue": {

--- a/packages/stylelint-plugin-slds/src/utils/styling-hook-utils.ts
+++ b/packages/stylelint-plugin-slds/src/utils/styling-hook-utils.ts
@@ -15,6 +15,9 @@ export function getStylingHooksForDensityValue(
   cssProperty: string
 ): string[] {
   const valueToMatch = parseUnitValue(value);
+  if (!valueToMatch) {
+    return [];
+  }
   const alternateValue = toAlternateUnitValue(valueToMatch.number, valueToMatch.unit);
   const matchedHooks = [];
 

--- a/packages/stylelint-plugin-slds/tests/rules/enforce-bem-usage/enforce-bem-usage.spec.ts
+++ b/packages/stylelint-plugin-slds/tests/rules/enforce-bem-usage/enforce-bem-usage.spec.ts
@@ -1,141 +1,139 @@
 
 import stylelint, { LinterResult, LinterOptions, LintResult } from 'stylelint';
+import plugins from '../../../src/index';
 const { lint }: typeof stylelint = stylelint;
-/**
- * Disableing tests for now. TODO: review later
- */
-xdescribe('enforce-bem-usage', () => {
+describe('enforce-bem-usage', () => {
   
   [
     {
       description: 'should report and fix bem usage when sole selector',
       input: `
-        .slds-text-heading_large {
-          border-start-start-radius: 0;
-        }
-      `,
-      expectedOutput: `
         .slds-text-heading--large {
           border-start-start-radius: 0;
         }
       `,
+      expectedOutput: `
+        .slds-text-heading_large {
+          border-start-start-radius: 0;
+        }
+      `,
       messages: [
-        "slds-text-heading_large has been retired. Update it to the new name slds-text-heading--large (slds/enforce-bem-usage)",
+        "slds-text-heading--large has been retired. Update it to the new name slds-text-heading_large (slds/enforce-bem-usage)",
       ],
-      messagePositions: [[1, 24]],
+      messagePositions: [[1, 25]],
     },
     {
       description: 'should report and fix bem usage when multiple selectors',
-      input: `
+      expectedOutput: `
         .slds-dl_horizontal__label,
         .slds-dl_horizontal__detail {
           display: none;
         }
       `,
-      expectedOutput: `
+      input: `
         .slds-dl--horizontal__label,
         .slds-dl--horizontal__detail {
           display: none;
         }
       `,
       messages: [
-        "slds-dl_horizontal__label has been retired. Update it to the new name slds-dl--horizontal__label (slds/enforce-bem-usage)",
-        "slds-dl_horizontal__detail has been retired. Update it to the new name slds-dl--horizontal__detail (slds/enforce-bem-usage)",
+        "slds-dl--horizontal__label has been retired. Update it to the new name slds-dl_horizontal__label (slds/enforce-bem-usage)",
+        "slds-dl--horizontal__detail has been retired. Update it to the new name slds-dl_horizontal__detail (slds/enforce-bem-usage)",
       ],
       messagePositions: [
-        [1, 26],
-        [37, 63],
+        [1, 27],
+        [38, 65],
       ],
     },
     {
       description: 'should report and fix bem usage in psuedo-selector',
-      input: `
+      expectedOutput: `
         .slds-dl_horizontal__label:last-of-type {
           border-bottom: none;
         }
       `,
-      expectedOutput: `
+      input: `
         .slds-dl--horizontal__label:last-of-type {
           border-bottom: none;
         }
       `,
       messages: [
-        "slds-dl_horizontal__label has been retired. Update it to the new name slds-dl--horizontal__label (slds/enforce-bem-usage)",
+        "slds-dl--horizontal__label has been retired. Update it to the new name slds-dl_horizontal__label (slds/enforce-bem-usage)",
       ],
-      messagePositions: [[1, 26]],
+      messagePositions: [[1, 27]],
     },
     {
       description: 'should report and fix bem usage in complex selector',
-      input: `
+      expectedOutput: `
         div.slds-dl_horizontal__label {
           border-bottom: none;
         }
       `,
-      expectedOutput: `
+      input: `
         div.slds-dl--horizontal__label {
           border-bottom: none;
         }
       `,
       messages: [
-        "slds-dl_horizontal__label has been retired. Update it to the new name slds-dl--horizontal__label (slds/enforce-bem-usage)",
+        "slds-dl--horizontal__label has been retired. Update it to the new name slds-dl_horizontal__label (slds/enforce-bem-usage)",
       ],
-      messagePositions: [[4, 29]],
+      messagePositions: [[4, 30]],
     },
     {
       description: 'should report and fix bem usage in chained selector',
-      input: `
+      expectedOutput: `
         .slds-dl_horizontal__label div {
           border-bottom: none;
         }
       `,
-      expectedOutput: `
+      input: `
         .slds-dl--horizontal__label div {
           border-bottom: none;
         }
       `,
       messages: [
-        "slds-dl_horizontal__label has been retired. Update it to the new name slds-dl--horizontal__label (slds/enforce-bem-usage)",
+        "slds-dl--horizontal__label has been retired. Update it to the new name slds-dl_horizontal__label (slds/enforce-bem-usage)",
       ],
-      messagePositions: [[1, 26]],
+      messagePositions: [[1, 27]],
     },
     {
       description: 'should report and fix bem usage in chained direct selector',
-      input: `
+      expectedOutput: `
         .slds-dl_horizontal__label > div {
           border-bottom: none;
         }
       `,
-      expectedOutput: `
+      input: `
         .slds-dl--horizontal__label > div {
           border-bottom: none;
         }
       `,
       messages: [
-        "slds-dl_horizontal__label has been retired. Update it to the new name slds-dl--horizontal__label (slds/enforce-bem-usage)",
+        "slds-dl--horizontal__label has been retired. Update it to the new name slds-dl_horizontal__label (slds/enforce-bem-usage)",
       ],
-      messagePositions: [[1, 26]],
+      messagePositions: [[1, 27]],
     },
     {
       description: 'should report and fix bem usage in chained direct selector',
-      input: `
+      expectedOutput: `
 .slds-dl_horizontal__label, .slds-dl_horizontal__detail {}
 
 .slds-dl_horizontal__label {}
       `,
-      expectedOutput: `
+      input: `
 .slds-dl--horizontal__label, .slds-dl--horizontal__detail {}
 
 .slds-dl--horizontal__label {}
       `,
       messages: [
-        "slds-dl_horizontal__label has been retired. Update it to the new name slds-dl--horizontal__label (slds/enforce-bem-usage)",
-        "slds-dl_horizontal__detail has been retired. Update it to the new name slds-dl--horizontal__detail (slds/enforce-bem-usage)",
-        "slds-dl_horizontal__label has been retired. Update it to the new name slds-dl--horizontal__label (slds/enforce-bem-usage)",
+        "slds-dl--horizontal__label has been retired. Update it to the new name slds-dl_horizontal__label (slds/enforce-bem-usage)",
+        "slds-dl--horizontal__detail has been retired. Update it to the new name slds-dl_horizontal__detail (slds/enforce-bem-usage)",
+        "slds-dl--horizontal__label has been retired. Update it to the new name slds-dl_horizontal__label (slds/enforce-bem-usage)",
       ],
       messagePositions: [
-        [1, 26],
-        [29, 55],
-        [1, 26],
+        [1, 27],
+        [30, 57],
+        [1, 27],
       ],
     },
   ].forEach(
@@ -149,8 +147,11 @@ xdescribe('enforce-bem-usage', () => {
         // Verify the reported messages
         const reportedMessages = lintResult._postcssResult?.messages.map(
           (message) => message.text
-        );
-        expect(messages).toContain(reportedMessages)
+        ) as string[];
+
+        reportedMessages.forEach((message, index) => {
+          expect(messages[index]).toEqual(message);
+        });
         const reportedPositions = lintResult._postcssResult?.messages.map(
           (message) => [message.index, message.endIndex]
         );
@@ -169,7 +170,7 @@ async function processLint(input: string, fixable = false) {
   const linterOptions: LinterOptions = {
     code: input,
     config: {
-      plugins: ['./src/index.ts'], // Adjust path as needed
+      plugins, // Adjust path as needed
       rules: {
         'slds/enforce-bem-usage': true,
       },

--- a/packages/stylelint-plugin-slds/tests/utils/styling-hook-utils.spec.ts
+++ b/packages/stylelint-plugin-slds/tests/utils/styling-hook-utils.spec.ts
@@ -77,15 +77,13 @@ describe('styling-hook-utils', () => {
     });
 
     it('should handle invalid value format', () => {
-      expect(() => {
-        getStylingHooksForDensityValue('invalid', mockStylingHooks, 'margin');
-      }).toThrow();
+      const result = getStylingHooksForDensityValue('invalid', mockStylingHooks, 'margin');
+      expect(result).toEqual([]);
     });
 
     it('should handle empty value', () => {
-      expect(() => {
-        getStylingHooksForDensityValue('', mockStylingHooks, 'margin');
-      }).toThrow();
+      const result = getStylingHooksForDensityValue('', mockStylingHooks, 'margin');
+      expect(result).toEqual([]);
     });
 
     it('should handle zero values', () => {


### PR DESCRIPTION
- Added error message for retired BEM class names in rules metadata.
- Improved handling of invalid density values in styling hook utilities.
- Updated tests for BEM usage to reflect new class name conventions and ensure accurate message reporting.