### PR TITLE
getRuleDescription function wasn't properly mapping rule IDs to YAML descriptions

### DIFF
--- a/packages/cli/src/services/config.resolver.ts
+++ b/packages/cli/src/services/config.resolver.ts
@@ -9,7 +9,10 @@ export const LINTER_CLI_VERSION = process.env.CLI_VERSION;
  * Get rule description from metadata
  */
 export const getRuleDescription = (ruleId: string): string => {
-  const ruleIdWithoutNameSpace = `${ruleId}`.replace(/\@salesforce-ux\//, '');
+  // Remove both @salesforce-ux/ namespace and slds/ prefix to match YAML keys
+  const ruleIdWithoutNameSpace = `${ruleId}`
+    .replace(/\@salesforce-ux\//, '')  // Remove npm namespace
+    .replace(/^slds\//, '');           // Remove slds/ prefix
   
   return ruleMessages[ruleIdWithoutNameSpace]?.description || '--';
 };


### PR DESCRIPTION
getRuleDescription function wasn't properly mapping rule IDs to YAML descriptions

<img width="1699" height="1010" alt="Screenshot 2025-09-18 at 2 54 36 PM" src="https://github.com/user-attachments/assets/89d6df27-cef9-44e0-9c6c-006bfed7270c" />
