### PR TITLE
ALLOWED_UNITS = ['px', 'em', 'rem', '%', 'ch'] in parity with earlier stylelint implementation

### DIFF
--- a/packages/eslint-plugin-slds/src/utils/hardcoded-shared-utils.ts
+++ b/packages/eslint-plugin-slds/src/utils/hardcoded-shared-utils.ts
@@ -1,6 +1,7 @@
 import { parse, walk } from '@eslint/css-tree';
 import type { HandlerContext } from '../types';
 import type { ParsedUnitValue } from './value-utils';
+import { ALLOWED_UNITS } from './value-utils';
 import { extractColorValue } from './color-lib-utils';
 import { isCssFunction } from './css-functions';
 
@@ -201,11 +202,11 @@ function extractDimensionValue(valueNode: any, cssProperty?: string): ParsedUnit
       if (numValue === 0) return null; // Skip zero values
       
       const unit = valueNode.unit.toLowerCase();
-      if (unit !== 'px' && unit !== 'rem' && unit !== '%') return null; // Support px, rem, and % units
+      if (!ALLOWED_UNITS.includes(unit)) return null; // Support only allowed units
       
       return {
         number: numValue,
-        unit: unit as 'px' | 'rem' | '%'
+        unit: unit as 'px' | 'rem' | '%' | 'em' | 'ch'
       };
       
     case 'Number':
@@ -278,11 +279,11 @@ function extractFontValue(node: any): ParsedUnitValue | null {
       if (numValue <= 0) return null; // Skip zero/negative values
       
       const unit = node.unit.toLowerCase();
-      if (unit !== 'px' && unit !== 'rem' && unit !== '%') return null;
+      if (!ALLOWED_UNITS.includes(unit)) return null;
       
       return {
         number: numValue,
-        unit: unit as 'px' | 'rem' | '%'
+        unit: unit as 'px' | 'rem' | '%' | 'em' | 'ch'
       };
       
     case 'Number':

--- a/packages/eslint-plugin-slds/src/utils/value-utils.ts
+++ b/packages/eslint-plugin-slds/src/utils/value-utils.ts
@@ -37,27 +37,32 @@ export function isGlobalValue(value: string): boolean {
     return value === 'initial' || value === 'inherit' || value === 'unset' || value === 'revert' || value === 'revert-layer';
   }
 
+// Configurable list of allowed CSS units
+export const ALLOWED_UNITS = ['px', 'em', 'rem', '%', 'ch'];
+
 export type ParsedUnitValue = {
-  unit: 'px' | 'rem' | '%' | null;
+  unit: 'px' | 'rem' | '%' | 'em' | 'ch' | null;
   number: number;
 } | null;
 
 export function parseUnitValue(value: string): ParsedUnitValue {
   if (!value) return null;
   
-  // Simple regex to parse number and unit
-  const match = value.match(/^(-?\d*\.?\d+)(px|rem|%)?$/);
+  // Create regex pattern from allowed units
+  const unitsPattern = ALLOWED_UNITS.join('|');
+  const regex = new RegExp(`^(-?\\d*\\.?\\d+)(${unitsPattern})?$`);
+  const match = value.match(regex);
   if (!match) return null;
   
   const number = parseFloat(match[1]);
-  const unit = match[2] ? (match[2] as 'px' | 'rem' | '%') : null; // Keep unitless values as null
+  const unit = match[2] ? (match[2] as 'px' | 'rem' | '%' | 'em' | 'ch') : null; // Keep unitless values as null
   
   if (isNaN(number)) return null;
   
   return { number, unit };
 }
 
-export function toAlternateUnitValue(numberVal: number, unitType: 'px' | 'rem' | '%' | null): ParsedUnitValue {
+export function toAlternateUnitValue(numberVal: number, unitType: 'px' | 'rem' | '%' | 'em' | 'ch' | null): ParsedUnitValue {
     if (unitType === 'px') {
       let floatValue = parseFloat(`${numberVal / 16}`);
       if (!isNaN(floatValue)) {
@@ -75,6 +80,7 @@ export function toAlternateUnitValue(numberVal: number, unitType: 'px' | 'rem' |
         }
       }
     }
-    // For unitless values (font-weight, etc.), no alternate unit conversion
+    // For other units (%, em, ch) and unitless values, no alternate unit conversion available
+    // These units are context-dependent and don't have standard conversion ratios
     return null;
 }

--- a/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds2.test.js
+++ b/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds2.test.js
@@ -107,6 +107,15 @@ ruleTester.run('no-hardcoded-values-slds2', rule, {
       code: `.example { font-weight: 450; }`,
       filename: 'test.css',
     },
+    // CSS units other than px/rem/% should be ignored when they have zero values
+    {
+      code: `.example { width: 0ch; }`,
+      filename: 'test.css',
+    },
+    {
+      code: `.example { font-size: 0em; }`,
+      filename: 'test.css',
+    },
   ],
   invalid: [
     // Hardcoded color with multiple suggestions
@@ -533,6 +542,41 @@ ruleTester.run('no-hardcoded-values-slds2', rule, {
         { messageId: 'hardcodedValue' }  // font-size: 1rem (line-height parsing not implemented)
       ],
       output: `.example { font: var(--slds-g-font-weight-7, 700) var(--slds-g-font-scale-2, 1rem)/1.5 Arial; }`
+    },
+
+    // NEW UNIT TESTS - CH and EM units
+    // Width with ch unit (character width) - should be detected and suggest sizing hook
+    {
+      code: `.example { width: 45ch; }`,
+      filename: 'test.css',
+      errors: [{ 
+        messageId: 'hardcodedValue'
+      }],
+      output: `.example { width: var(--slds-g-sizing-content-2, 45ch); }`
+    },
+    // Font-size with em unit - should be detected but no hook available
+    {
+      code: `.example { font-size: 1.2em; }`,
+      filename: 'test.css',
+      errors: [{ 
+        messageId: 'noReplacement'
+      }]
+    },
+    // Max-width with ch unit - should be detected but no hook available
+    {
+      code: `.example { max-width: 80ch; }`,
+      filename: 'test.css',
+      errors: [{ 
+        messageId: 'noReplacement'
+      }]
+    },
+    // Line-height with em unit - should be detected but no hook available
+    {
+      code: `.example { line-height: 1.5em; }`,
+      filename: 'test.css',
+      errors: [{ 
+        messageId: 'noReplacement'
+      }]
     }
   ]
 });


### PR DESCRIPTION
ALLOWED_UNITS = ['px', 'em', 'rem', '%', 'ch'] in parity with earlier stylelint implementation