### PR TITLE
wrong properties also reported because of regex match fixed

### DIFF
--- a/packages/eslint-plugin-slds/src/utils/property-matcher.ts
+++ b/packages/eslint-plugin-slds/src/utils/property-matcher.ts
@@ -106,8 +106,9 @@ export function toSelector(properties: string[]): string {
   const selectorParts = properties.map(prop => {
     if (prop.includes('*')) {
       // Convert wildcards to regex patterns for CSS AST selectors
+      // Anchor to start of string to prevent matching CSS custom properties
       const regexPattern = prop.replace(/\*/g, '.*');
-      return `Declaration[property=/${regexPattern}$/]`;
+      return `Declaration[property=/^${regexPattern}$/]`;
     } else {
       // Exact property match
       return `Declaration[property='${prop}']`;

--- a/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds1.test.js
+++ b/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds1.test.js
@@ -63,6 +63,36 @@ ruleTester.run('no-hardcoded-values-slds1', rule, {
     {
       code: `.example { font: 0 Arial; }`,
       filename: 'test.css',
+    },
+    // CSS custom property declarations should be ignored (these define the hooks, not use hardcoded values)
+    {
+      code: `.global-example { --slds-g-color-border-base-2: #dddbda; }`,
+      filename: 'test.css',
+    },
+    {
+      code: `.global-example { --slds-g-color-border-base-3: #c9c7c5; }`,
+      filename: 'test.css',
+    },
+    {
+      code: `.global-example { --slds-g-spacing-small: 0.5rem; }`,
+      filename: 'test.css',
+    },
+    {
+      code: `.global-example { --slds-g-font-size-1: 0.75rem; }`,
+      filename: 'test.css',
+    },
+    {
+      code: `.global-example { --slds-g-shadow-outset: 0 0 0 1px #e5e5e5; }`,
+      filename: 'test.css',
+    },
+    // Multiple CSS custom property declarations in one rule
+    {
+      code: `.global-example {
+        --slds-g-color-border-base-2: #dddbda;
+        --slds-g-color-border-base-3: #c9c7c5;
+        --slds-g-spacing-small: 0.5rem;
+      }`,
+      filename: 'test.css',
     }
   ],
   invalid: [

--- a/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds2.test.js
+++ b/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds2.test.js
@@ -116,6 +116,36 @@ ruleTester.run('no-hardcoded-values-slds2', rule, {
       code: `.example { font-size: 0em; }`,
       filename: 'test.css',
     },
+    // CSS custom property declarations should be ignored (these define the hooks, not use hardcoded values)
+    {
+      code: `.global-example { --slds-g-color-border-base-2: #dddbda; }`,
+      filename: 'test.css',
+    },
+    {
+      code: `.global-example { --slds-g-color-border-base-3: #c9c7c5; }`,
+      filename: 'test.css',
+    },
+    {
+      code: `.global-example { --slds-g-spacing-small: 0.5rem; }`,
+      filename: 'test.css',
+    },
+    {
+      code: `.global-example { --slds-g-font-size-1: 0.75rem; }`,
+      filename: 'test.css',
+    },
+    {
+      code: `.global-example { --slds-g-shadow-outset: 0 0 0 1px #e5e5e5; }`,
+      filename: 'test.css',
+    },
+    // Multiple CSS custom property declarations in one rule
+    {
+      code: `.global-example {
+        --slds-g-color-border-base-2: #dddbda;
+        --slds-g-color-border-base-3: #c9c7c5;
+        --slds-g-spacing-small: 0.5rem;
+      }`,
+      filename: 'test.css',
+    },
   ],
   invalid: [
     // Hardcoded color with multiple suggestions


### PR DESCRIPTION
CSS custom properties will be properly ignored by the no-hardcoded-values rule.