### PR TITLE
Box-shadow with CSS variables is now processed (previously skipped entirely)

### DIFF
--- a/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds2.test.js
+++ b/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds2.test.js
@@ -603,6 +603,15 @@ ruleTester.run('no-hardcoded-values-slds2', rule, {
       errors: [{ 
         messageId: 'noReplacement'
       }]
+    },
+    // Box-shadow with CSS variables now processed and matched to hook (previously skipped entirely)
+    {
+      code: `.example { box-shadow: 0 0 0 2px var(--slds-g-color-brand-base-15) inset, 0 0 0 4px var(--slds-g-color-neutral-base-100) inset; }`,
+      filename: 'test.css',
+      output: `.example { box-shadow: var(--slds-g-shadow-insetinverse-focus-1, 0 0 0 2px var(--slds-g-color-brand-base-15) inset, 0 0 0 4px var(--slds-g-color-neutral-base-100) inset); }`,
+      errors: [{
+        messageId: 'hardcodedValue'
+      }]
     }
   ]
 });


### PR DESCRIPTION
    Box-shadow with CSS variables is now processed (previously skipped entirely)
<img width="869" height="170" alt="Screenshot 2025-09-22 at 5 25 11 PM" src="https://github.com/user-attachments/assets/88de3e8b-2c83-4d44-9e85-866547a4472a" />
