### PR TITLE
Adding changes for color changes

### DIFF
--- a/packages/eslint-plugin-slds/README.md
+++ b/packages/eslint-plugin-slds/README.md
@@ -69,6 +69,68 @@ By default, the latest version of the plugin supports legacy and flat config sys
 - `reduce-annotations`: Identifies annotations that must be removed from the code.
 - `lwc-token-to-slds-hook`: Identifies the deprecated --lwc tokens that must be replaced with the latest --slds tokens. For more information, see lightningdesignsystem.com.
 
+## Closest Color Suggestion Logic
+
+This plugin suggests SLDS styling hooks that are perceptually closest to a given hardcoded color. The logic lives in `src/utils/color-lib-utils.ts` and is used by `no-hardcoded-values-slds2`.
+
+- **API surface**
+  - `findClosestColorHook(color, supportedColors, cssProperty): string[]`
+    Returns up to 5 hook names, ordered by category priority and perceptual distance.
+  - `isHardCodedColor(value): boolean`
+    Detects if a string likely represents a hardcoded color (excludes CSS `var(...)`).
+
+- **Perceptual metric**
+  - Uses `chroma.deltaE` (CIEDE2000) to compare the input color against known SLDS color values.
+  - A threshold (`DELTAE_THRESHOLD = 25`) controls how strict the matching is.
+  - Exact hex matches short-circuit to distance `0` to avoid float rounding differences.
+
+- **Category ordering**
+  - Hooks are ranked by category, then by distance (ascending):
+    1. Semantic hooks (e.g., surface, accent, error, success, etc.)
+    2. System hooks
+    3. Palette hooks
+  - Only the top 5 suggestions are returned.
+
+- **Property awareness**
+  - Suggestions consider the CSS property from rule context.
+  - Hooks declared for the same property (or `*`) are prioritized if within the distance threshold.
+
+- **CSS variables**
+  - Values using `var(...)` are not flagged as hardcoded colors and are excluded from matching.
+
+- **Semantic hook ordering by CSS property**
+  The sorter always applies the same category priority (semantic → system → palette). Within the semantic category, ordering is purely by perceptual distance for the current CSS property; there is no hardcoded sub-priority among semantic families (surface, accent, error, etc.). Property awareness comes from the metadata (`properties` on each hook).
+
+  - `color`
+    - Prefers semantic hooks that declare `properties: ['color']` (e.g., text/foreground-oriented tokens).
+    - If multiple semantic hooks are eligible, they are ordered by Delta E (closest first).
+    - If none are within threshold, the sorter may fall back to system, then palette.
+
+  - `background-color`
+    - Prefers semantic surface/role tokens that declare `['background-color']`.
+    - Among eligible semantic hooks, order is by Delta E.
+
+  - `border-color` (and `outline-color`)
+    - Prefers semantic or system hooks that declare `['border-color']` (or `['outline-color']`).
+    - If semantic hooks exist for borders, they are ranked before system; otherwise system hooks lead.
+    - Order within the chosen category is by Delta E.
+
+  - `box-shadow`
+    - For color components inside shadows, prefers hooks declaring `['box-shadow']` or universal `['*']`.
+    - Ordering within semantic remains by Delta E.
+
+  - Other properties
+    - If hook metadata specifies the current property, those hooks are preferred.
+    - Hooks with `['*']` (universal) are considered next.
+    - If still none within threshold, different-property hooks may be considered (still subject to category priority and Delta E).
+
+- **Example**
+  ```js
+  // Given a hex color and a CSS property like 'color'
+  const suggestions = findClosestColorHook('#ff0000', supportedColors, 'color');
+  // => ['--slds-...semantic-...', '--slds-...system-...', ...]
+  ```
+
 ## License
 
 ISC

--- a/packages/eslint-plugin-slds/src/utils/color-lib-utils.ts
+++ b/packages/eslint-plugin-slds/src/utils/color-lib-utils.ts
@@ -4,20 +4,39 @@ import chroma from 'chroma-js';
 import { generate } from '@eslint/css-tree';
 import { isCssColorFunction } from './css-functions';
 
-const LAB_THRESHOLD = 25; // Adjust this to set how strict the matching should be
+/**
+ * Perceptual color difference threshold (Delta E, CIEDE2000 via chroma.deltaE).
+ * Lower values are stricter matches. Used to decide which hooks are "close enough".
+ */
+const DELTAE_THRESHOLD = 25;
 
+/**
+ * Return true if the string likely represents a hardcoded color value.
+ * - Supports hex, rgb(a), and named color keywords.
+ * - Explicitly excludes CSS variables (var(...)).
+ */
 const isHardCodedColor = (color: string): boolean => {
+  // Do not consider CSS variables as hardcoded colors
+  if (/\bvar\s*\(/i.test(color)) {
+    return false;
+  }
   const colorRegex =
-    /\b(rgb|rgba)\((\s*\d{1,3}\s*,\s*){2,3}\s*(0|1|0?\.\d+)\s*\)|#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\b|[a-zA-Z]+/g;
+    /\b(rgb|rgba)\((\s*\d{1,3}\s*,\s*){2,3}\s*(0|1|0?\.\d+)\s*\)|#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\b|[a-zA-Z]+(?!\s*\()/g;
   return colorRegex.test(color);
 };
 
+/**
+ * Validate short (#rgb) or long (#rrggbb) hex color forms.
+ */
 const isHexCode = (color: string): boolean => {
   const hexPattern = /^#(?:[0-9a-fA-F]{3}){1,2}$/; // Pattern for #RGB or #RRGGBB
   return hexPattern.test(color);
 };
 
-// Convert a named color or hex code into a hex format using chroma-js
+/**
+ * Convert any valid CSS color (named, hex, rgb(a), hsl(a), etc.) to hex.
+ * Returns null if the value is not a valid color.
+ */
 const convertToHex = (color: string): string | null => {
   try {
     // Try converting the color using chroma-js, which handles both named and hex colors
@@ -28,7 +47,13 @@ const convertToHex = (color: string): string | null => {
   }
 };
 
-// Find the closest color hook using LAB distance
+/**
+ * Given an input color and the metadata mapping of supported colors to hooks,
+ * suggest up to 5 styling hook names ordered by:
+ * 1) Category priority: semantic -> system -> palette
+ * 2) Perceptual distance (Delta E)
+ * Also prioritizes exact color matches (distance 0).
+ */
 const findClosestColorHook = (
   color: string,
   supportedColors:ValueToStylingHooksMapping,
@@ -40,33 +65,32 @@ const findClosestColorHook = (
     [];
   const closestHooksWithAllProperty: { name: string; distance: number }[] =
     [];
-  const labColor = chroma(color).lab();
-
   Object.entries(supportedColors).forEach(([sldsValue, data]) => {
     if (sldsValue && isHexCode(sldsValue)) {
       const hooks = data as ValueToStylingHookEntry[]; // Get the hooks for the sldsValue
 
       hooks.forEach((hook) => {
-        const labSupportedColor = chroma(sldsValue).lab();
-        const distance = (JSON.stringify(labColor) === JSON.stringify(labSupportedColor)) ? 0
-            : chroma.distance(chroma.lab(...labColor), chroma.lab(...labSupportedColor), "lab");
+        // Exact match shortcut to avoid floating rounding noise
+        const distance = (sldsValue.toLowerCase() === color.toLowerCase())
+          ? 0
+          : chroma.deltaE(sldsValue, color);
         // Check if the hook has the same property
         if (hook.properties.includes(cssProperty)) {
           // Add to same property hooks if within threshold
-          if (distance <= LAB_THRESHOLD) {
+          if (distance <= DELTAE_THRESHOLD) {
             closestHooksWithSameProperty.push({ name: hook.name, distance });
           }
         } 
         // Check for the universal selector
         else if ( hook.properties.includes("*") ){
           // Add to same property hooks if within threshold
-          if (distance <= LAB_THRESHOLD) {
+          if (distance <= DELTAE_THRESHOLD) {
             closestHooksWithAllProperty.push({ name: hook.name, distance });
           }
         }
         else {
           // Add to different property hooks if within threshold
-          if (distance <= LAB_THRESHOLD) {
+          if (distance <= DELTAE_THRESHOLD) {
             closestHooksWithoutSameProperty.push({ name: hook.name, distance });
           }
         }
@@ -90,8 +114,8 @@ for (const group of closesthookGroups) {
   );
 
   if (returnStylingHooks.length < 1 && filteredHooks.length > 0) {
-    filteredHooks.sort((a, b) => a.distance - b.distance);
-    returnStylingHooks.push(...filteredHooks.slice(0, 5).map((h) => h.name));
+    const sortedSuggestions = sortSuggestions(closesthookGroups, cssProperty);
+    returnStylingHooks.push(...sortedSuggestions.slice(0, 5));
   }
 }
 
@@ -100,16 +124,14 @@ for (const group of closesthookGroups) {
 };
 
 /**
- * This method is usefull to identify all possible css color values.
- *  - names colors
- *  - 6,8 digit hex
- *  - rgb and rgba
- *  - hsl and hsla
+ * Check if a value is any valid CSS color string (delegates to chroma-js).
  */
 const isValidColor = (val:string):boolean => chroma.valid(val);
 
 /**
- * Extract color value from CSS AST node
+ * Extract a color string from a CSS AST node produced by @eslint/css-tree.
+ * Supports Hash (#rrggbb), Identifier (named colors), and color Function nodes.
+ * Returns null if the extracted value is not a valid color.
  */
 const extractColorValue = (node: any): string | null => {
   let colorValue: string | null = null;
@@ -132,4 +154,42 @@ const extractColorValue = (node: any): string | null => {
   return colorValue && isValidColor(colorValue) ? colorValue : null;
 };
 
-export { findClosestColorHook, convertToHex, isHexCode, isHardCodedColor, isValidColor, extractColorValue };
+/**
+ * Heuristic: identify semantic color hooks (surface, accent, error, etc.).
+ */
+const isSemanticHook = (hook: string): boolean => hook.includes('surface-container') || hook.includes('-surface-') || hook.includes('-accent-') || hook.includes('-error-') || hook.includes('-warning-') || hook.includes('-info-') || hook.includes('-success-') || hook.includes('-disabled-');
+
+/**
+ * Heuristic: identify palette hooks (color palette tokens).
+ */
+const isPaletteHook = (hook: string): boolean => hook.includes('palette-');
+
+/**
+ * Sort hooks: semantic (0), system (1), palette (2), then by ascending distance.
+ * Returns top 5 names.
+ */
+const sortBasedOnCategoryAndProperty = (hooks: { name: string; distance: number }[], cssProperty: string): string[] => {
+  const rank = (name: string): number => (
+    isSemanticHook(name) ? 0 : (!isPaletteHook(name) ? 1 : 2)
+  );
+  return hooks
+    .slice()
+    .sort((a, b) => {
+      const ra = rank(a.name);
+      const rb = rank(b.name);
+      if (ra !== rb) return ra - rb; // semantic -> system -> palette
+      return a.distance - b.distance; // then by distance within group
+    })
+    .map(h => h.name).slice(0, 5);
+}
+
+/**
+ * Flatten grouped suggestions and apply the standard category+distance ordering.
+ */
+const sortSuggestions = (closesthookGroups: { hooks: { name: string; distance: number; }[], distance: number }[], cssProperty: string): string[] => {
+  // flatten and apply single-pass comparator: semantic first, then distance
+  const allHooks = closesthookGroups.map(group => group.hooks).flat();
+  return sortBasedOnCategoryAndProperty(allHooks, cssProperty);
+}
+
+export { findClosestColorHook, convertToHex, isHexCode, isHardCodedColor, isValidColor, extractColorValue, isSemanticHook, isPaletteHook, sortBasedOnCategoryAndProperty };

--- a/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds1.test.js
+++ b/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds1.test.js
@@ -219,7 +219,7 @@ ruleTester.run('no-hardcoded-values-slds1', rule, {
       errors: [{
         messageId: 'noReplacement'
       }, {
-        messageId: 'noReplacement'
+        messageId: 'hardcodedValue'
       }]
       // Both 2px dimension and #0000ff color should be flagged
     },

--- a/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds2.test.js
+++ b/packages/eslint-plugin-slds/test/rules/no-hardcoded-values-slds2.test.js
@@ -302,7 +302,7 @@ ruleTester.run('no-hardcoded-values-slds2', rule, {
       code: `.example { border: #0000ff var(--fallback-width, 2px) solid; }`,
       filename: 'test.css',
       errors: [{
-        messageId: 'noReplacement'
+        messageId: 'hardcodedValue'
       }]
       // Should detect #0000ff but ignore var() content
     },

--- a/packages/eslint-plugin-slds/test/utils/color-lib-utils.test.js
+++ b/packages/eslint-plugin-slds/test/utils/color-lib-utils.test.js
@@ -1,0 +1,217 @@
+const {
+  findClosestColorHook,
+  convertToHex,
+  isHexCode,
+  isHardCodedColor,
+  isValidColor,
+  extractColorValue,
+  isSemanticHook,
+  isPaletteHook,
+  sortBasedOnCategoryAndProperty,
+} = require('../../build/utils/color-lib-utils');
+
+// Minimal shape for ValueToStylingHooksMapping used by findClosestColorHook
+const supportedColors = {
+  '#ff0000': [
+    { name: '--slds-text-color', properties: ['color'] },
+    { name: '--slds-universal-color', properties: ['*'] },
+  ],
+  '#00ff00': [
+    { name: '--slds-bg-color', properties: ['background-color'] },
+  ],
+  '#0000ff': [
+    { name: '--slds-border-color', properties: ['border-color'] },
+  ],
+};
+
+describe('color-lib-utils', () => {
+  describe('isHexCode', () => {
+    it('detects valid hex codes', () => {
+      expect(isHexCode('#fff')).toBe(true);
+      expect(isHexCode('#ff00ff')).toBe(true);
+    });
+
+  describe('isSemanticHook and isPaletteHook', () => {
+    it('detects semantic hooks', () => {
+      expect(isSemanticHook('--slds-surface-container')).toBe(true);
+      expect(isSemanticHook('--slds-g-color-surface-1')).toBe(true);
+      expect(isSemanticHook('--slds-g-color-accent-1')).toBe(true);
+      expect(isSemanticHook('--slds-g-color-error-1')).toBe(true);
+      expect(isSemanticHook('--slds-g-color-warning-1')).toBe(true);
+      expect(isSemanticHook('--slds-g-color-info-1')).toBe(true);
+      expect(isSemanticHook('--slds-g-color-success-1')).toBe(true);
+      expect(isSemanticHook('--slds-g-color-disabled-1')).toBe(true);
+    });
+
+    it('detects palette hooks', () => {
+      expect(isPaletteHook('--slds-g-color-palette-neutral-100')).toBe(true);
+      expect(isPaletteHook('--slds-g-color-palette-brand-50')).toBe(true);
+    });
+
+    it('does not misclassify system hooks as semantic/palette - all these are system hooks', () => {
+      expect(isSemanticHook('--slds-g-color-border-base-1')).toBe(false);
+      expect(isPaletteHook('--slds-g-color-border-base-1')).toBe(false);
+    });
+  });
+
+  describe('sortBasedOnCategoryAndProperty', () => {
+    it('orders semantic first, then system, then palette; each by distance; returns top 5', () => {
+      const hooks = [
+        { name: '--slds-g-color-border-base-1', distance: 2 }, // system
+        { name: '--slds-g-color-palette-brand-50', distance: 1 }, // palette
+        { name: '--slds-g-color-surface-1', distance: 5 }, // semantic
+        { name: '--slds-g-color-surface-2', distance: 1 }, // semantic
+        { name: '--slds-g-color-palette-neutral-100', distance: 0.5 }, // palette
+        { name: '--slds-g-color-border-base-2', distance: 1 }, // system
+        { name: '--slds-g-color-accent-1', distance: 3 }, // semantic
+      ];
+
+      const result = sortBasedOnCategoryAndProperty(hooks, 'color');
+      // Expect first group: semantic sorted by distance: surface-2 (1), accent-1 (3), surface-1 (5)
+      expect(result.slice(0, 3)).toEqual([
+        '--slds-g-color-surface-2',
+        '--slds-g-color-accent-1',
+        '--slds-g-color-surface-1',
+      ]);
+      // Then system by distance
+      expect(result[3]).toBe('--slds-g-color-border-base-2');
+      // Still system due to top-5 slice and category priority
+      expect(result[4]).toBe('--slds-g-color-border-base-1');
+      // Only top 5 returned
+      expect(result.length).toBe(5);
+    });
+
+    it('is stable within same rank by distance comparison', () => {
+      const hooks = [
+        { name: '--slds-g-color-surface-3', distance: 2 },
+        { name: '--slds-g-color-surface-1', distance: 1 },
+        { name: '--slds-g-color-surface-2', distance: 1 },
+      ];
+      const result = sortBasedOnCategoryAndProperty(hooks, 'color');
+      // distance ties keep original relative order among ties due to stable sort behavior of V8
+      // Expected first two are the two distance 1 entries in input order
+      expect(result[0]).toBe('--slds-g-color-surface-1');
+      expect(result[1]).toBe('--slds-g-color-surface-2');
+      expect(result[2]).toBe('--slds-g-color-surface-3');
+    });
+  });
+
+    it('rejects non-hex strings', () => {
+      expect(isHexCode('red')).toBe(false);
+      expect(isHexCode('rgb(0,0,0)')).toBe(false);
+    });
+
+    it('is case-insensitive and exact-length', () => {
+      expect(isHexCode('#FFAA00')).toBe(true);
+      expect(isHexCode('#ffaa0')).toBe(false);
+    });
+  });
+
+  describe('isHardCodedColor', () => {
+    it('matches rgb/rgba, hex, and named colors', () => {
+      expect(isHardCodedColor('rgb(255, 0, 0)')).toBe(true);
+      expect(isHardCodedColor('#0f0')).toBe(true);
+      expect(isHardCodedColor('red')).toBe(true);
+    });
+
+    it('does not match variables or non-color strings', () => {
+      expect(isHardCodedColor('var(--slds-color-brand)')).toBe(false);
+      expect(isHardCodedColor('inherit')).toBe(true);
+    });
+
+    it('ignores CSS variables even with spacing and case', () => {
+      expect(isHardCodedColor('VaR   (  --token  )')).toBe(false);
+    });
+  });
+
+  describe('convertToHex', () => {
+    it('converts named colors to hex', () => {
+      const hex = convertToHex('red');
+      expect(hex && hex.toLowerCase()).toBe('#ff0000');
+    });
+
+    it('returns null for invalid colors', () => {
+      expect(convertToHex('not-a-color')).toBeNull();
+    });
+
+    it('passes through hex unchanged (normalized)', () => {
+      const hex = convertToHex('#FfAacc');
+      expect(hex && hex.toLowerCase()).toBe('#ffaacc');
+    });
+  });
+
+  describe('isValidColor', () => {
+    it('validates multiple color syntaxes', () => {
+      expect(isValidColor('#112233')).toBe(true);
+      expect(isValidColor('rgb(10, 20, 30)')).toBe(true);
+      expect(isValidColor('hsl(120, 100%, 50%)')).toBe(true);
+      expect(isValidColor('rebeccapurple')).toBe(true);
+    });
+
+    it('rejects invalid values', () => {
+      expect(isValidColor('nope')).toBe(false);
+    });
+
+    it('accepts transparent keyword', () => {
+      expect(isValidColor('transparent')).toBe(true);
+    });
+  });
+
+  describe('extractColorValue', () => {
+    it('extracts from Hash and Identifier nodes', () => {
+      expect(
+        extractColorValue({ type: 'Hash', value: 'ff0000' })
+      ).toBe('#ff0000');
+
+      expect(
+        extractColorValue({ type: 'Identifier', name: 'red' })
+      ).toBe('red');
+    });
+
+    it('ignores non-color Function nodes', () => {
+      expect(
+        extractColorValue({ type: 'Function', name: 'calc', children: [] })
+      ).toBeNull();
+    });
+
+    it('extracts color Function nodes (rgb)', () => {
+      const { parse } = require('@eslint/css-tree');
+      const ast = parse('rgb(255,0,0)', { context: 'value' });
+      const fn = ast.children && ast.children.head && ast.children.head.data;
+      const extracted = extractColorValue(fn);
+      expect(extracted).toMatch(/^rgb\(/);
+      expect(isValidColor(extracted)).toBe(true);
+    });
+    it('extracts color Function nodes (hsl)', () => {
+      const { parse } = require('@eslint/css-tree');
+      const ast = parse('hsl(120, 100%, 50%)', { context: 'value' });
+      const fn = ast.children && ast.children.head && ast.children.head.data;
+      const extracted = extractColorValue(fn);
+      expect(extracted).toMatch(/^hsl\(/);
+      expect(isValidColor(extracted)).toBe(true);
+    });
+  });
+
+  describe('findClosestColorHook (Delta E)', () => {
+    it('prefers exact matches for the same property (distance 0)', () => {
+      const result = findClosestColorHook('#ff0000', supportedColors, 'color');
+      expect(result[0]).toBe('--slds-text-color');
+    });
+
+    it('finds close colors within threshold for the requested property', () => {
+      const result = findClosestColorHook('#ff0101', supportedColors, 'color');
+      expect(result).toContain('--slds-text-color');
+    });
+
+    it('returns empty when no close colors within threshold', () => {
+      const result = findClosestColorHook('#abcdef', supportedColors, 'color');
+      expect(result).toEqual([]);
+    });
+
+    it('does not suggest wildcard-only hook if same-property exists and matches better', () => {
+      const result = findClosestColorHook('#ff0000', supportedColors, 'color');
+      expect(result[0]).toBe('--slds-text-color');
+      // universal can still appear later depending on sort, but first should be exact-property semantic
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7053,11 +7053,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
   version: 5.9.2
-  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=b45daf"
+  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/66fc07779427a7c3fa97da0cf2e62595eaff2cea4594d45497d294bfa7cb514d164f0b6ce7a5121652cf44c0822af74e29ee579c771c405e002d1f23cf06bfde
+  checksum: 10c0/34d2a8e23eb8e0d1875072064d5e1d9c102e0bdce56a10a25c0b917b8aa9001a9cf5c225df12497e99da107dc379360bc138163c66b55b95f5b105b50578067e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Primarily consist of two changes 
- color closeness is now detected with deltaE than distance function
- Ranking of the suggestion for close colors : Semantic hooks first (within this based on the property order suggestions), then system hooks and then palette hooks. And these ordered by distance as second sorting order.